### PR TITLE
Security fixes for production mode

### DIFF
--- a/deploy/deploy-sota-local.yml
+++ b/deploy/deploy-sota-local.yml
@@ -82,4 +82,5 @@ services:
       CORE_HOST: "core"
       RESOLVER_PORT: "8081"
       RESOLVER_HOST: "resolver"
+      PLAY_CRYPTO_SECRET: {{ play_crypto_secret }}
 

--- a/deploy/docker-launcher.yml.example
+++ b/deploy/docker-launcher.yml.example
@@ -14,3 +14,4 @@ vars:
   db_user_password: "s0ta"
   db_resolver_name: "sota_resolver"
   db_core_name: "sota_core"
+  play_crypto_secret: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"

--- a/gen-secret.sh
+++ b/gen-secret.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+secret=`head -c 500 /dev/urandom | tr -dc 'a-zA-Z0-9~!@#$%^&*_-' | fold -w 64 | head -n 1`
+echo $secret | tr -d '\n'

--- a/web-server/accounts.json
+++ b/web-server/accounts.json
@@ -1,1 +1,0 @@
-[{"email":"admin@sota.com","password":"$2a$10$G2qZTx9PviXB7Q3.FaI4DODqIaoUHo8HqS0DY30zjCiMRlbW4K9lC","name":"Admin","role":"USER"}]

--- a/web-server/conf/accounts.json
+++ b/web-server/conf/accounts.json
@@ -1,0 +1,1 @@
+[{"email":"admin@genivi.org","password":"$2a$10$G2qZTx9PviXB7Q3.FaI4DODqIaoUHo8HqS0DY30zjCiMRlbW4K9lC","name":"Admin","role":"USER"}]

--- a/web-server/conf/application.conf
+++ b/web-server/conf/application.conf
@@ -8,7 +8,8 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-play.crypto.secret = "changeme"
+play.crypto.secret="YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
+play.crypto.secret=${?PLAY_CRYPTO_SECRET}
 
 # The application languages
 # ~~~~~
@@ -79,7 +80,7 @@ test.webserver.host  = ${?RESOLVER_HOST}
 #the default test port is already specified by scalatest
 test.webserver.port  = ${?RESOLVER_PORT}
 
-file.password = "accounts.json"
+file.password = "conf/accounts.json"
 
 # Evolutions
 # ~~~~~

--- a/web-server/test/ApplicationFunTests.scala
+++ b/web-server/test/ApplicationFunTests.scala
@@ -52,7 +52,7 @@ class ApplicationFunTests extends PlaySpec with OneServerPerSuite with AllBrowse
       "allow users to add and search for vins " + browser.name in {
         val testVin = "TESTVIN0123456789"
         go to (s"http://$webHost:$webPort/login")
-        emailField("email").value = "admin@sota.com"
+        emailField("email").value = "admin@genivi.org"
         pwdField("password").value = "genivirocks!"
         submit()
         eventually {
@@ -70,7 +70,7 @@ class ApplicationFunTests extends PlaySpec with OneServerPerSuite with AllBrowse
 
       "allow users to add packages " + browser.name in {
         go to (s"http://$webHost:$webPort/login")
-        emailField("email").value = "admin@sota.com"
+        emailField("email").value = "admin@genivi.org"
         pwdField("password").value = "genivirocks!"
         submit()
         eventually {
@@ -95,7 +95,7 @@ class ApplicationFunTests extends PlaySpec with OneServerPerSuite with AllBrowse
       "allow users to add filters " + browser.name in {
         val filterName = "Testfilter"
         go to (s"http://$webHost:$webPort/login")
-        emailField("email").value = "admin@sota.com"
+        emailField("email").value = "admin@genivi.org"
         pwdField("password").value = "genivirocks!"
         submit()
         eventually {

--- a/web-server/test/Authentication/AccountUnitTests.scala
+++ b/web-server/test/Authentication/AccountUnitTests.scala
@@ -9,7 +9,7 @@ import scala.language.reflectiveCalls
 class AccountUnitTests extends PlaySpec with OneServerPerSuite {
 
   def fixture = new {
-    val email = "admin@sota.com"
+    val email = "admin@genivi.org"
     val name = "admin"
     val password = "genivirocks!"
     val role = Role.USER

--- a/web-server/test/Authentication/LoginFunTest.scala
+++ b/web-server/test/Authentication/LoginFunTest.scala
@@ -16,7 +16,7 @@ class LoginFunTest extends PlaySpec with OneServerPerSuite {
 
   "refuse incorrect passwords" in {
     val response = await(WS.url(s"http://localhost:$port/authenticate").withFollowRedirects(true).post(Map(
-    "email" -> Seq("admin@sota.com"),
+    "email" -> Seq("admin@genivi.org"),
     "password" -> Seq("invalidpassword"))))
     response.status mustBe (BAD_REQUEST)
     response.body must include("Sign in")
@@ -24,7 +24,7 @@ class LoginFunTest extends PlaySpec with OneServerPerSuite {
 
   "redirect logins to index page" in {
     val response = await(WS.url(s"http://localhost:$port/authenticate").post(Map(
-      "email" -> Seq("admin@sota.com"),
+      "email" -> Seq("admin@genivi.org"),
       "password" -> Seq("genivirocks!"))))
     response.status mustBe (OK)
     response.body must include("SOTA Web Admin")


### PR DESCRIPTION
 - Disable secure option for set-cookie so logins work without SSL
 - Change the default play secret and add script to generate one, to be
   passed in using env vars when running in docker
 - Move accounts.json to conf so it can be found in docker container at
   runtime