### PR TITLE
Make listing packages for filters and vice versa fail if package or

### DIFF
--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/Packages.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/Packages.scala
@@ -36,9 +36,9 @@ object Packages {
 
   case object MissingPackageException extends Throwable with NoStackTrace
 
-  def exists(name: Package.Name, version: Package.Version)(implicit ec: ExecutionContext): DBIO[Unit] =
+  def exists(name: Package.Name, version: Package.Version)(implicit ec: ExecutionContext): DBIO[Package] =
     packages
       .filter(p => p.name === name && p.version === version)
       .result
-      .map(pkgs => if (pkgs.isEmpty) throw MissingPackageException else ())
+      .map(ps => if(ps.isEmpty) throw MissingPackageException else ps.head)
 }

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageFilterResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageFilterResourceSpec.scala
@@ -46,7 +46,6 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
 
     "not allow assignment of non-existing filters to existing packages " in {
       addPackageFilter(pkgName, pkgVersion, "nonexistant") ~> route ~> check {
-
         status shouldBe StatusCodes.NotFound
         responseAs[ErrorRepresentation].code shouldBe PackageFilter.MissingFilter
       }
@@ -66,6 +65,19 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
       }
     }
 
+    "fail to list packages associated to empty filter names" in {
+      listPackagesForFilter("") ~> route ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    "fail to list packages associated to non-existant filters" in {
+      listPackagesForFilter("nonexistant") ~> route ~> check {
+        status shouldBe StatusCodes.NotFound
+        responseAs[ErrorRepresentation].code shouldBe PackageFilter.MissingFilter
+      }
+    }
+
     "list filters associated to a package on GET requests to /filtersFor/:packageName" in {
       listFiltersForPackage(pkgName, pkgVersion) ~> route ~> check {
         status shouldBe StatusCodes.OK
@@ -79,8 +91,20 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
       }
     }
 
+    "fail to list filters associated to a package if a non-existant package name is given" in {
+      listFiltersForPackage("nonexistant", pkgVersion) ~> route ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
     "fail to list filters associated to a package if no package version is given" in {
       listFiltersForPackage(pkgName, "") ~> route ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    "fail to list filters associated to a package if a non-existant package version is given" in {
+      listFiltersForPackage(pkgName, "6.6.6") ~> route ~> check {
         status shouldBe StatusCodes.NotFound
       }
     }


### PR DESCRIPTION
filter id doesn't exist. Found by @tkfu.