### PR TITLE
Add default params for rvi.

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -50,6 +50,10 @@ packages = {
 }
 
 rvi {
+  host = "localhost"
+  host = ${?RVI_HOST}
+  port = 8801
+  port = ${?RVI_PORT}
   endpoint = "http://127.0.0.1:8801"
   endpoint = ${?RVI_URI}
 }


### PR DESCRIPTION
Without these defaults, core will fail to start.