### PR TITLE
Fix redirect failing to show update

### DIFF
--- a/web-server/app/assets/javascripts/mixins/show-model.jsx
+++ b/web-server/app/assets/javascripts/mixins/show-model.jsx
@@ -1,11 +1,9 @@
 define(['jquery', 'react'], function($, React) {
   var showModel = {
     getStateFromStore: function () {
-      if (this.props.Store.length === 0) {
-        this.props.Store.once('sync', function(collection) {
-          this.stateFromStore();
-        }, this);
-      }
+      this.props.Store.once('sync', function(collection) {
+        this.stateFromStore();
+      }, this);
       return this.whereClause();
     },
     componentWillReceiveProps: function(props, context) {


### PR DESCRIPTION
Store is now sync'd every time instead of just when it is empty.
This fixes a race condition which was causing the update details page
to get stuck on the loading screen forever.