### PR TITLE
Rename vehicle package to vehicles to be consistant with packages (which

### DIFF
--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -18,7 +18,7 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.common.RefinementDirectives.refinedPackageId
 import org.genivi.sota.resolver.db._
 import org.genivi.sota.resolver.types.{Filter, PackageFilter}
-import org.genivi.sota.resolver.vehicle._
+import org.genivi.sota.resolver.vehicles._
 import org.genivi.sota.resolver.packages._
 import org.genivi.sota.rest.Handlers.{rejectionHandler, exceptionHandler}
 import org.genivi.sota.rest.{ErrorCode, ErrorRepresentation}

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/FilterDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/FilterDirectives.scala
@@ -16,7 +16,7 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.db.{Filters, PackageFilters}
 import org.genivi.sota.resolver.types.{Filter, PackageFilter}
 import org.genivi.sota.resolver.packages._
-import org.genivi.sota.resolver.vehicle._
+import org.genivi.sota.resolver.vehicles._
 import org.genivi.sota.rest.Validation._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/InstalledPackages.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/InstalledPackages.scala
@@ -5,7 +5,7 @@
 package org.genivi.sota.resolver.db
 
 import org.genivi.sota.refined.SlickRefined._
-import org.genivi.sota.resolver.vehicle.Vehicle
+import org.genivi.sota.resolver.vehicles.Vehicle
 import org.genivi.sota.resolver.packages.Package
 import slick.driver.MySQLDriver.api._
 

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/types/FilterAST.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/types/FilterAST.scala
@@ -9,7 +9,7 @@ import eu.timepit.refined.string.{Regex, regexPredicate}
 import scala.util.parsing.combinator.syntactical.StandardTokenParsers
 import scala.util.parsing.combinator.{PackratParsers, ImplicitConversions}
 import org.genivi.sota.resolver.packages.Package
-import org.genivi.sota.resolver.vehicle.Vehicle
+import org.genivi.sota.resolver.vehicles.Vehicle
 
 
 sealed abstract trait FilterAST

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/Vehicle.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/Vehicle.scala
@@ -2,7 +2,7 @@
  * Copyright: Copyright (C) 2015, Jaguar Land Rover
  * License: MPL-2.0
  */
-package org.genivi.sota.resolver.vehicle
+package org.genivi.sota.resolver.vehicles
 
 import eu.timepit.refined.{Refined, Predicate}
 import org.genivi.sota.rest.ErrorCode

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleDAO.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleDAO.scala
@@ -2,7 +2,7 @@
  * Copyright: Copyright (C) 2015, Jaguar Land Rover
  * License: MPL-2.0
  */
-package org.genivi.sota.resolver.vehicle
+package org.genivi.sota.resolver.vehicles
 
 import org.genivi.sota.refined.SlickRefined._
 

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleDirectives.scala
@@ -2,7 +2,7 @@
  * Copyright: Copyright (C) 2015, Jaguar Land Rover
  * License: MPL-2.0
  */
-package org.genivi.sota.resolver.vehicle
+package org.genivi.sota.resolver.vehicles
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.NoContent

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleFunctions.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/vehicles/VehicleFunctions.scala
@@ -2,7 +2,7 @@
  * Copyright: Copyright (C) 2015, Jaguar Land Rover
  * License: MPL-2.0
  */
-package org.genivi.sota.resolver.vehicle
+package org.genivi.sota.resolver.vehicles
 
 import org.genivi.sota.resolver.packages.{Package, PackageFunctions}
 import org.genivi.sota.resolver.Errors

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Requests.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Requests.scala
@@ -14,7 +14,7 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport
 import CirceMarshallingSupport._
 import org.genivi.sota.resolver.DependenciesDirectives.makeFakeDependencyMap
 import org.genivi.sota.resolver.packages.Package
-import org.genivi.sota.resolver.vehicle.Vehicle
+import org.genivi.sota.resolver.vehicles.Vehicle
 import org.genivi.sota.resolver.types.{Filter, PackageFilter}
 import org.scalatest.Matchers
 import scala.concurrent.duration._

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ResolveResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ResolveResourceSpec.scala
@@ -5,7 +5,7 @@ import eu.timepit.refined.Refined
 import io.circe.generic.auto._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.packages.Package
-import org.genivi.sota.resolver.vehicle.Vehicle
+import org.genivi.sota.resolver.vehicles.Vehicle
 import org.genivi.sota.resolver.types.PackageFilter
 import org.genivi.sota.resolver.Errors.Codes
 import org.genivi.sota.rest.{ErrorRepresentation, ErrorCodes}

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
@@ -12,7 +12,7 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport
 import CirceMarshallingSupport._
 import org.genivi.sota.resolver.Errors.Codes
 import org.genivi.sota.resolver.packages.Package
-import org.genivi.sota.resolver.vehicle.Vehicle
+import org.genivi.sota.resolver.vehicles.Vehicle
 import org.genivi.sota.resolver.types.PackageFilter
 import org.genivi.sota.rest.{ErrorCodes, ErrorRepresentation}
 import org.scalacheck._


### PR DESCRIPTION
can't simply be named package, because that's a keyword).