### PR TITLE
Allow logins over HTTP

### DIFF
--- a/web-server/app/org/genivi/webserver/controllers/AuthConfigImpl.scala
+++ b/web-server/app/org/genivi/webserver/controllers/AuthConfigImpl.scala
@@ -113,7 +113,7 @@ trait AuthConfigImpl extends AuthConfig {
      * Whether use the secure option or not use it in the cookie.
      * However default is false, I strongly recommend using true in a production.
      */
-    cookieSecureOption = play.api.Play.isProd(play.api.Play.current),
+    cookieSecureOption = false,
     cookieMaxAge       = Some(sessionTimeoutInSeconds)
   )
 


### PR DESCRIPTION
Simplifies the deployment of SOTA by eliminating a common gotcha. The cookieSecureOption doesn't provide much meaningful protection at this point in time since it's still a prototype. This change can be reverted in future once SOTA is more mature.