### PR TITLE
Add a data container to persist data on teardown

### DIFF
--- a/deploy/deploy-sota-local.yml
+++ b/deploy/deploy-sota-local.yml
@@ -1,5 +1,15 @@
 ---
 services:
+  - name: sota-data
+    repo: busybox
+    state: present
+    restart_policy: 'no'
+    volumes:
+      - /var/lib/mysql
+      - /tmp/
+      - /var/lib/sota
+    command: "true"
+
   - name: mysql
     repo: advancedtelematic/mariadb
     ports:
@@ -9,6 +19,8 @@ services:
       MYSQL_USER: "{{ db_user }}"
       MYSQL_PASSWORD: "{{ db_user_password }}"
       MYSQL_DATABASES: "{{ db_resolver_name }} {{ db_core_name }} {{ db_core_name }}_test {{ db_resolver_name }}_test"
+    volumes_from:
+      - sota-data
 
   - name: rvi-server
     repo: advancedtelematic/rvi
@@ -40,6 +52,8 @@ services:
       - rvi-client
     env:
       SOTA_CLIENT_PORT: "8090"
+    volumes_from:
+      - sota-data
 
   - name: resolver
     repo: advancedtelematic/sota-resolver
@@ -67,16 +81,19 @@ services:
       - rvi-server
     env:
       HOST: 0.0.0.0
+      SOTA_SERVICES_URI: "http://core:8080/rvi"
       CORE_DB_URL: "jdbc:mysql://mysql:3306/{{ db_core_name }}"
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi-server:8801"
+    volumes_from:
+      - sota-data
 
   - name: webserver
     repo: advancedtelematic/sota-webserver
+    pull: false
     links:
       - resolver
       - core
-    pull: false
     ports:
       - 80:9000
     env:


### PR DESCRIPTION
This adds a data-only container to persist data even on `--teardown`. To
delete the data for good you can run `docker rm -fv sota-data`.

* the database is stored in `/var/lib/mysql`
* packages uploaded to the server are stored in `/tmp`
* packages downloaded to the client are stored in `/var/lib/sota`

Needs `docker-launcher` version 0.1.8 to work.