### PR TITLE
Add autoresponder deployment

### DIFF
--- a/deploy/deploy-sota-debug.yml
+++ b/deploy/deploy-sota-debug.yml
@@ -10,7 +10,7 @@ services:
       - /var/lib/sota
     command: "true"
 
-  - name: mysql
+  - name: sota-mysql
     repo: advancedtelematic/mariadb
     ports:
       - 3306
@@ -25,12 +25,15 @@ services:
   - name: rvi-server
     repo: advancedtelematic/rvi
     attach: true
+    pull: false
     ports:
       - 8801
       - 8805
       - 8806
       - 8807
       - 8808
+    env:
+      RVI_LOGLEVEL: "debug"
     command: server
 
   - name: resolver
@@ -41,10 +44,10 @@ services:
     expose:
       - "8081"
     links:
-      - mysql
+      - sota-mysql
     env:
       HOST: 0.0.0.0
-      RESOLVER_DB_URL: "jdbc:mysql://mysql:3306/{{ db_resolver_name }}"
+      RESOLVER_DB_URL: "jdbc:mariadb://sota-mysql:3306/{{ db_resolver_name }}"
 
   - name: core
     repo: advancedtelematic/sota-core
@@ -54,13 +57,13 @@ services:
     expose:
       - "8080"
     links:
-      - mysql
+      - sota-mysql
       - resolver
       - rvi-server
     env:
       HOST: 0.0.0.0
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-      CORE_DB_URL: "jdbc:mysql://mysql:3306/{{ db_core_name }}"
+      CORE_DB_URL: "jdbc:mariadb://sota-mysql:3306/{{ db_core_name }}"
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi-server:8801"
     volumes_from:
@@ -78,4 +81,30 @@ services:
       CORE_API_URI: "http://core:8080"
       RESOLVER_API_URI: "http://resolver:8081"
       PLAY_CRYPTO_SECRET: {{ play_crypto_secret }}
+
+  - name: rvi-client
+    repo: advancedtelematic/rvi
+    attach: true
+    pull: false
+    ports:
+      - 8901
+      - 8905
+      - 8906
+      - 8907
+      - 8908
+    links: [rvi-server]
+    env:
+      RVI_LOGLEVEL: "debug"
+      RVI_BACKEND: "rvi-server"
+    command: client
+
+  - name: sota-client-debug
+    repo: advancedtelematic/sota-client-debug
+    ports: [8090]
+    links: [rvi-client]
+    env:
+      LOGLEVEL: "trace"
+      RVI_ADDR: "rvi-client"
+      SOTA_CLIENT_ADDR: "sota-client-debug"
+      SOTA_CLIENT_PORT: "8090"
 


### PR DESCRIPTION
This adds a Docker Launcher stack config for deploying a full SOTA demo
with the client autoresponder connected to the sota client. This means
all download requests are automatically accepted and downloaded. It is
intended for debugging and automatic integration tests