### PR TITLE
Add automatic migrations

### DIFF
--- a/deploy/deploy-sota-debug.yml
+++ b/deploy/deploy-sota-debug.yml
@@ -10,7 +10,7 @@ services:
       - /var/lib/sota
     command: "true"
 
-  - name: sota-mysql
+  - name: mysql
     repo: advancedtelematic/mariadb
     ports:
       - 3306
@@ -25,13 +25,8 @@ services:
   - name: rvi-server
     repo: advancedtelematic/rvi
     attach: true
-    pull: false
     ports:
       - 8801
-      - 8805
-      - 8806
-      - 8807
-      - 8808
     env:
       RVI_LOGLEVEL: "debug"
     command: server
@@ -44,10 +39,10 @@ services:
     expose:
       - "8081"
     links:
-      - sota-mysql
+      - mysql
     env:
       HOST: 0.0.0.0
-      RESOLVER_DB_URL: "jdbc:mariadb://sota-mysql:3306/{{ db_resolver_name }}"
+      RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_resolver_name }}"
 
   - name: core
     repo: advancedtelematic/sota-core
@@ -57,13 +52,13 @@ services:
     expose:
       - "8080"
     links:
-      - sota-mysql
+      - mysql
       - resolver
       - rvi-server
     env:
       HOST: 0.0.0.0
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-      CORE_DB_URL: "jdbc:mariadb://sota-mysql:3306/{{ db_core_name }}"
+      CORE_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_core_name }}"
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi-server:8801"
     volumes_from:
@@ -88,10 +83,6 @@ services:
     pull: false
     ports:
       - 8901
-      - 8905
-      - 8906
-      - 8907
-      - 8908
     links: [rvi-server]
     env:
       RVI_LOGLEVEL: "debug"
@@ -108,3 +99,11 @@ services:
       SOTA_CLIENT_ADDR: "sota-client-debug"
       SOTA_CLIENT_PORT: "8090"
 
+  - name: sota-migration
+    repo: advancedtelematic/sota-migration
+    restart_policy: 'no'
+    links:
+      - mysql
+    env:
+      RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_resolver_name }}"
+      CORE_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_core_name }}"

--- a/deploy/deploy-sota-local.yml
+++ b/deploy/deploy-sota-local.yml
@@ -27,10 +27,6 @@ services:
     attach: true
     ports:
       - 8801
-      - 8805
-      - 8806
-      - 8807
-      - 8808
     command: server
 
   - name: resolver
@@ -44,7 +40,7 @@ services:
       - mysql
     env:
       HOST: 0.0.0.0
-      RESOLVER_DB_URL: "jdbc:mysql://mysql:3306/{{ db_resolver_name }}"
+      RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_resolver_name }}"
 
   - name: core
     repo: advancedtelematic/sota-core
@@ -60,7 +56,7 @@ services:
     env:
       HOST: 0.0.0.0
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-      CORE_DB_URL: "jdbc:mysql://mysql:3306/{{ db_core_name }}"
+      CORE_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_core_name }}"
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi-server:8801"
     volumes_from:
@@ -79,3 +75,11 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       PLAY_CRYPTO_SECRET: {{ play_crypto_secret }}
 
+  - name: sota-migration
+    repo: advancedtelematic/sota-migration
+    restart_policy: 'no'
+    links:
+      - mysql
+    env:
+      RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_resolver_name }}"
+      CORE_DB_URL: "jdbc:mariadb://mysql:3306/{{ db_core_name }}"

--- a/deploy/migration/Dockerfile
+++ b/deploy/migration/Dockerfile
@@ -1,0 +1,12 @@
+FROM advancedtelematic/sbt:0.13.8
+
+RUN apt-get update \
+ && apt-get install -y git
+
+RUN git clone https://github.com/advancedtelematic/rvi_sota_server.git
+WORKDIR /app/rvi_sota_server
+
+# fetch dependencies
+RUN sbt flywayMigrate || true
+
+CMD ["/usr/local/sbt/bin/sbt", "flywayMigrate"]

--- a/docs/_posts/2015-08-26-deployment-with-docker-launcher.adoc
+++ b/docs/_posts/2015-08-26-deployment-with-docker-launcher.adoc
@@ -23,22 +23,18 @@ You will need a Docker Hub account (https://hub.docker.com/).
 
 == Deploying a Development System
 
-To deploy a local development system, there are 3 basic steps.
-
-=== 1. Build the local docker images
+Deploying with docker-launcher is quite easy: first, build the images:
 
 [source,sh]
 -------------------------
 ./sbt docker:publishLocal
 -------------------------
 
-Once this completes successfully, you may deploy with https://github.com/advancedtelematic/docker-launcher[Docker Launcher.]
+And then you may deploy with https://github.com/advancedtelematic/docker-launcher[Docker Launcher.]
 
-=== 2. Launch the docker images with docker-launcher
+Make sure you have Docker Launcher and Docker installed and configured to your liking. Docker Launcher currently requires Docker >= v.1.8.0 and Ansible v.1.9.2. Ansible 2.x has not yet been tested, and is not guaranteed to work.
 
-For deploying a development system to your local machine, make sure you have Docker Launcher and Docker installed and configured to your liking. Docker Launcher currently requires Docker >= v.1.8.0 and Ansible v.1.9.2. Ansible 2.x has not yet been tested, and is not guaranteed to work.
-
-First, enter the `deploy` directory, and copy the example Docker Launcher configuration file, then edit it to match your preferences. The only values you should need to change are the `user` and `email` fields in `docker-launcher.yml`. These should be a valid username and associated email address for Docker Hub.
+Enter the `deploy` directory, copy the example Docker Launcher configuration file, and run it.
 
 [source,sh]
 --------------------------------------------------
@@ -47,14 +43,7 @@ cp docker-launcher.yml.example docker-launcher.yml
 docker-launcher -c docker-launcher.yml deploy-sota-local.yml
 --------------------------------------------------
 
-You will be prompted for your Docker Hub password, but for a local deployment it's not actually needed.
-
-=== 3. Apply database migrations to the newly created MariaDB container
-
-[source,sh]
-------------------------------------------------------------
-CORE_DB_URL=jdbc:mariadb://<your-docker-host>:3306/sota_core RESOLVER_DB_URL=jdbc:mariadb://<your-docker-host>:3306/sota_resolver sbt flywayMigrate
-------------------------------------------------------------
+You will be prompted for your Docker Hub password, but for a local deployment it's not actually needed. You can just press enter at the prompt.
 
 === Teardown
 


### PR DESCRIPTION
This adds automatic migrations to the docker-launcher stacks. It works
by creating a Docker image with the latest source code and sbt installed
and then running `sbt flywayMigrate` against the linked in mysql
container. The migrations container is kept around to avoid rerunning
the migrations every time.