### PR TITLE
Generalise search for vehicles. It's now possible to search for vehicles

### DIFF
--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -56,6 +56,6 @@ object Boot extends App {
 
   sys.addShutdownHook {
     Try( db.close()  )
-    Try( system.shutdown() )
+    Try( system.terminate() )
   }
 }

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
@@ -39,7 +39,7 @@ object ComponentRepository {
   def removeComponent(part: Component.PartNumber)
                      (implicit ec: ExecutionContext): DBIO[Int] =
     for {
-      vs <- VehicleRepository.vinsThatHaveComponent(part)
+      vs <- VehicleRepository.search(None, None, None, Some(part))
       r  <- if (vs.nonEmpty) DBIO.failed(Errors.ComponentIsInstalledException)
             else components.filter(_.partNumber === part).delete
     } yield r


### PR DESCRIPTION
that have a VIN matching a regex, some package installed and some
component installed. Previously one could only search by one of those
criteria at the time.