### PR TITLE
add note about ssl for AWS deployment

### DIFF
--- a/docs/_posts/2015-08-26-deployment-with-docker-launcher.adoc
+++ b/docs/_posts/2015-08-26-deployment-with-docker-launcher.adoc
@@ -105,6 +105,10 @@ With `<user>`, `<password>`, and `<host>` replaced with suitable values.
 
 Deployment of rvi-sota-server requires valid AWS administrator credentials, as well as an SSH key to administer any instances launched by the vw-garage deployment scripts.
 
+=== SSL
+
+The current version of SOTA Server is SSL insensitive; for a production system using SSL use an SSL-stripping load balancer.
+
 ==== Create New User for Deployment
 
 For security purposes, we recommend creating a new IAM user to manage the deployment. This user will have full access to the AWS services, but will not have the capability to create new users. If the credentials for the *deploy* user are compromised, they can be reset using the root AWS account.


### PR DESCRIPTION
* for acceptance testing notes #4 "Installation of SSL certificate is not explained. If 'production mode' is the default setting then the documentation must explain how to create and install the certificate. We should make 'development mode' the default and explain how to enable 'production mode' including the creation an installation of certificates."

* This could arguably just be ignored; "production mode" isn't a thing anymore in head. Personally, I think this adds more confusion than clarity, but it may be required for acceptance.