### PR TITLE
Fix vins with pkg installed displaying all vins

### DIFF
--- a/web-server/app/assets/javascripts/handlers/vehicles.js
+++ b/web-server/app/assets/javascripts/handlers/vehicles.js
@@ -44,7 +44,7 @@ define(function(require) {
               });
           break;
           case 'get-vehicles-for-package':
-            sendRequest.doGet('/api/v1/vehicles?package=' + payload.name + '-' + payload.version)
+            sendRequest.doGet('/api/v1/vehicles?packageName=' + payload.name + '&packageVersion=' + payload.version)
               .success(function(vehicles) {
                 var list = _.map(vehicles, function(vehicle) {
                   return vehicle.vin;


### PR DESCRIPTION
This commit corrects the url syntax used so the list of vins with a
package installed is actually correct, instead of simply displaying
every vin on the system