### PR TITLE
Make Package version format configurable

### DIFF
--- a/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
@@ -7,6 +7,7 @@ package org.genivi.sota.data
 
 import cats.{Eq, Show}
 import eu.timepit.refined.api.Validate
+import com.typesafe.config.ConfigFactory
 
 case class PackageId(
                  name   : PackageId.Name,
@@ -50,9 +51,11 @@ object PackageId {
       ValidName()
     )
 
+  private val packageVersionFormat = ConfigFactory.load.getString("packages.versionFormat")
+
   implicit val validPackageVersion: Validate.Plain[String, ValidVersion] =
     Validate.fromPredicate(
-      _.matches( """^\d+\.\d+\.\d+$""" ),
+      _.matches( packageVersionFormat ),
       _ => "Invalid version format",
       ValidVersion()
     )

--- a/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
@@ -46,19 +46,20 @@ object PackageId {
   implicit val validPackageName: Validate.Plain[String, ValidName] =
     Validate.fromPredicate(
       s => s.length > 0 && s.length <= 100
-        && s.forall(c => c.isLetter || c.isDigit),
+        && s.forall(c => c.isLetter || c.isDigit || List('-', '+', '.').contains(c)),
       s => s"$s: isn't a valid package name (between 1 and 100 character long alpha numeric string)",
       ValidName()
     )
 
-  private val packageVersionFormat = ConfigFactory.load.getString("packages.versionFormat")
+  implicit val validPackageVersion: Validate.Plain[String, ValidVersion] = {
+    val packageFormat = ConfigFactory.load().getString("packages.versionFormat")
 
-  implicit val validPackageVersion: Validate.Plain[String, ValidVersion] =
     Validate.fromPredicate(
-      _.matches( packageVersionFormat ),
+      _.matches(packageFormat),
       _ => "Invalid version format",
       ValidVersion()
     )
+  }
 
 
   /**

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -44,6 +44,8 @@ upload {
 }
 
 packages = {
+  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = ${?PACKAGES_VERSION_FORMAT}
   absolutePath = "/usr/local/packages"
   absolutePath = ${?PACKAGES_PATH}
   extension = "rpm"

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -44,7 +44,7 @@ upload {
 }
 
 packages = {
-  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = """^\d+\.\d+\.\d+$"""
   versionFormat = ${?PACKAGES_VERSION_FORMAT}
   absolutePath = "/usr/local/packages"
   absolutePath = ${?PACKAGES_PATH}

--- a/docs/_posts/2015-08-26-building-installing.adoc
+++ b/docs/_posts/2015-08-26-building-installing.adoc
@@ -92,6 +92,8 @@ sbt webserver/run
 
 TIP: The SOTA Core server looks for the RVI server node on localhost by default. If your RVI node is running somewhere else (i.e. if you're running docker on a mac), you will need to specify `RVI_URI` as an environment variable. If your docker host was 192.168.99.100, for example, you would run `RVI_URI="http://192.168.99.100:8801" sbt core/run`.
 
+TIP: The version format of packages is configurable, defaulting to MAJOR.MINOR.PATCH, where MAJOR, MINOR, and PATCH are unsigned integers. To change the format, specify a regular expression in the `PACKAGES_VERSION_FORMAT` environment variable.
+
 Now open http://localhost:9000/[localhost:9000] in a browser.
 
 === Troubleshooting

--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -22,6 +22,11 @@ database {
   migrate = ${?RESOLVER_DB_MIGRATE}
 }
 
+packages {
+  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = ${?PACKAGES_VERSION_FORMAT}
+}
+
 test-database = ${database}
 test-database = {
   url = "jdbc:mariadb://localhost:3306/sota_resolver_test"

--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -23,7 +23,7 @@ database {
 }
 
 packages {
-  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = """^\d+\.\d+\.\d+$"""
   versionFormat = ${?PACKAGES_VERSION_FORMAT}
 }
 

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
@@ -219,7 +219,9 @@ class VehiclesResourceWordSpec extends ResourceWordSpec {
     "list installed packages on a VIN on GET request to /vehicles/:vin/package" in {
       Get(Resource.uri(vehicles, vin.get, "package")) ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[PackageId]] shouldBe List(PackageId(refineMV("apa"), refineMV("1.0.1")))
+        val name: PackageId.Name = Refined.unsafeApply("apa")
+        val version: PackageId.Version = Refined.unsafeApply("1.0.1")
+        responseAs[Seq[PackageId]] shouldBe List(PackageId(name, version))
       }
     }
 

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -90,7 +90,7 @@ object SotaBuild extends Build {
 
   lazy val commonData = Project(id = "common-data", base = file("common-data"))
     .settings(basicSettings ++ compilerSettings)
-    .settings(libraryDependencies ++= Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.CommonsCodec)
+    .settings(libraryDependencies ++= Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.CommonsCodec :+ Dependencies.TypesafeConfig)
     .settings(publishSettings)
 
   lazy val commonTest = Project(id = "common-test", base = file("common-test"))
@@ -209,6 +209,8 @@ object Dependencies {
   lazy val Flyway = "org.flywaydb" % "flyway-core" % "3.2.1"
 
   lazy val TestFrameworks = Seq( ScalaTest, ScalaCheck )
+
+  lazy val TypesafeConfig = "com.typesafe" % "config" % "1.3.0"
 
   lazy val Database = Seq (
     "com.typesafe.slick" %% "slick" % "3.0.2",

--- a/web-server/conf/application.conf
+++ b/web-server/conf/application.conf
@@ -58,6 +58,11 @@ core.database {
   validationTimeout = 5000
 }
 
+packages {
+  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = ${?PACKAGES_VERSION_FORMAT}
+}
+
 resolver.database {
   driver = "org.mariadb.jdbc.Driver"
   url = "jdbc:mariadb://localhost:3306/sota_resolver"

--- a/web-server/conf/application.conf
+++ b/web-server/conf/application.conf
@@ -59,7 +59,7 @@ core.database {
 }
 
 packages {
-  versionFormat = "^\d+\.\d+\.\d+$"
+  versionFormat = """^\d+\.\d+\.\d+$"""
   versionFormat = ${?PACKAGES_VERSION_FORMAT}
 }
 


### PR DESCRIPTION
Configurable by setting the `PACKAGES_VERSION_FORMAT` env var. Defaults to the current 1.2.3 format.