### PR TITLE
configurable communication backend (default RVI)

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -30,6 +30,11 @@ server = {
   port = ${?PORT}
 }
 
+core {
+  interactionProtocol = "rvi" # or "none"
+  interactionProtocol = ${?CORE_INTERACTION_PROTOCOL}
+}
+
 resolver = {
   baseUri = "http://localhost:8081"
   baseUri = ${?RESOLVER_API_URI}

--- a/core/src/main/scala/org/genivi/sota/core/Connectivity.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Connectivity.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import com.github.nscala_time.time.Imports.DateTime
+import io.circe.{Encoder, Json}
+import scala.concurrent.Future
+
+import org.genivi.sota.core.jsonrpc.HttpTransport
+
+trait Connectivity {
+  implicit val transport: Json => Future[Json]
+  implicit val client: ConnectivityClient
+}
+
+object DefaultConnectivity extends Connectivity {
+  // TODO: to be implemented
+  override implicit val transport = { (_: Json) =>
+    Future.successful(Json.empty)
+  }
+  override implicit val client = DefaultConnectivityClient
+}
+
+/**
+ * Abstract interface for sending a message to the backing communication layer.
+ */
+trait ConnectivityClient {
+  def sendMessage[A](service: String, message: A, expirationDate: DateTime)
+                    (implicit encoder: Encoder[A] ) : Future[Int]
+}
+
+object DefaultConnectivityClient extends ConnectivityClient {
+  override def sendMessage[A](service: String, message: A, expirationDate: DateTime)
+                             (implicit encoder: Encoder[A]) = {
+    // TODO: to be implemented
+    Future.successful(0)
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviClient.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviClient.scala
@@ -4,26 +4,18 @@
  */
 package org.genivi.sota.core.rvi
 
-import io.circe.Encoder
+import com.github.nscala_time.time.Imports.DateTime
+import io.circe._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Random
-import com.github.nscala_time.time.Imports.DateTime
 
-/**
- * Abstract interface for sending a message to RVI.
- */
-trait RviClient {
-  def sendMessage[A](service: String, message: A, expirationDate: DateTime)
-                    (implicit encoder: Encoder[A] ) : Future[Int]
-}
-
-import io.circe._
+import org.genivi.sota.core.ConnectivityClient
 
 /**
  * Concrete implementation for sending a message to RVI in JSON-RPC format.
  */
-class JsonRpcRviClient(transport: Json => Future[Json], ec: ExecutionContext) extends RviClient {
+class JsonRpcRviClient(transport: Json => Future[Json], ec: ExecutionContext) extends ConnectivityClient {
 
   import shapeless._
   import shapeless.syntax.singleton._

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviConnectivity.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviConnectivity.scala
@@ -1,0 +1,23 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.rvi
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.http.scaladsl.model.Uri
+import scala.concurrent.ExecutionContext
+
+import org.genivi.sota.core.Connectivity
+import org.genivi.sota.core.jsonrpc.HttpTransport
+
+
+class RviConnectivity(implicit system: ActorSystem,
+                      mat: ActorMaterializer,
+                      ec: ExecutionContext) extends Connectivity {
+
+  val rviUri = Uri(system.settings.config.getString("rvi.endpoint"))
+  override implicit val transport = HttpTransport(rviUri).requestTransport
+  override implicit val client = new JsonRpcRviClient(transport, system.dispatcher)
+}

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
@@ -1,0 +1,39 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.rvi
+
+import akka.event.LoggingAdapter
+import org.genivi.sota.core.Connectivity
+import org.genivi.sota.core.data.UpdateSpec
+import org.genivi.sota.core.transfer._
+import org.genivi.sota.data.Vehicle
+import org.joda.time.DateTime
+import scala.concurrent.{ExecutionContext, Future}
+
+
+/**
+ * Send a notification to SOTA clients via RVI that there are packages that
+ * can/should be updated.
+ */
+class RviUpdateNotifier(services: ServerServices) extends UpdateNotifier {
+
+  import io.circe.generic.auto._
+
+  override def notifyVehicle(vin: Vehicle.Vin, update: UpdateSpec)
+                            (implicit connectivity: Connectivity, ec: ExecutionContext): Future[Int] = {
+    import com.github.nscala_time.time.Imports._
+    import io.circe.generic.auto._
+
+    def toPackageUpdate( spec: UpdateSpec ) = {
+      val r = spec.request
+      PackageUpdate(r.id, r.signature, r.description.getOrElse(""), r.requestConfirmation, spec.size)
+    }
+
+    val expirationDate: DateTime = update.request.periodOfValidity.getEnd
+    connectivity.client.sendMessage(s"genivi.org/vin/${vin.get}/sota/notify",
+                                    UpdateNotification(toPackageUpdate(update), services), expirationDate)
+  }
+
+}

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
@@ -7,18 +7,19 @@ import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.util.FastFuture
 import io.circe.Encoder
+import io.circe.generic.auto._
 import java.util.UUID
 import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.core.data.UpdateRequest
 import org.genivi.sota.core.db.UpdateRequests
+import org.genivi.sota.core.rvi.{ServerServices, RviConnectivity}
+import org.genivi.sota.core.transfer.DefaultUpdateNotifier
 import org.scalacheck.Gen
 import org.scalatest.{Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
 import scala.concurrent.Future
 import slick.jdbc.JdbcBackend.Database
-import io.circe.generic.auto._
 import CirceMarshallingSupport._
-import org.genivi.sota.core.rvi.{ServerServices, RviClient}
 
 /**
  * Spec tests for update-request REST actions
@@ -44,16 +45,10 @@ class UpdateRequestSpec extends PropSpec with PropertyChecks with Matchers with 
 
   class Service(implicit system: ActorSystem) {
     implicit val log = Logging(system, "updateRequestsSpec")
-    implicit val rviClient = new RviClient {
-
-      import org.joda.time.DateTime
-      override def sendMessage[A](service: String, message: A, expirationDate: DateTime)
-        (implicit encoder: Encoder[A] ) : Future[Int] = FastFuture.successful(0)
-
-    }
+    implicit val connectivity = DefaultConnectivity
 
     val resource = new UpdateRequestsResource(db, externalResolverClient,
-                                              new UpdateService( ServerServices("", "", "", "")))
+                                              new UpdateService(DefaultUpdateNotifier))
   }
 
   import UpdateRequest._

--- a/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
@@ -5,22 +5,18 @@ import akka.http.scaladsl.util.FastFuture
 import akka.testkit.TestKit
 import eu.timepit.refined.api.Refined
 import java.util.UUID
-
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.db.{Packages, UpdateSpecs, Vehicles}
+import org.genivi.sota.core.transfer.DefaultUpdateNotifier
 import org.genivi.sota.data.{PackageId, Vehicle, VehicleGenerators}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalatest.time.Millis
-import org.scalatest.time.Second
-import org.scalatest.time.Span
-import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
-
+import org.scalatest.time.{Millis, Second, Span}
+import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
+import scala.concurrent.{Await, Future}
 import scala.util.Random
 import slick.jdbc.JdbcBackend._
-
-import scala.concurrent.{Await, Future}
 
 /**
  * Spec tests for Update service
@@ -47,17 +43,10 @@ class UpdateServiceSpec extends PropSpec with PropertyChecks with Matchers with 
 
   implicit val updateQueueLog = akka.event.Logging(system, "sota.core.updateQueue")
 
-  import org.genivi.sota.core.rvi.{RviClient, ServerServices}
-  implicit val rviClient =  new RviClient {
+  import org.genivi.sota.core.Connectivity
+  implicit val connectivity = DefaultConnectivity
 
-    import org.joda.time.DateTime
-    import io.circe.Encoder
-    def sendMessage[A](service: String, message: A, expirationDate: DateTime)
-      (implicit encoder: Encoder[A] ) : Future[Int] = FastFuture.successful(0)
-
-  }
-
-  val service = new UpdateService( ServerServices("", "", "", "") )
+  val service = new UpdateService(DefaultUpdateNotifier)
 
   import org.genivi.sota.core.data.UpdateRequest
   import org.scalatest.concurrent.ScalaFutures.{whenReady, PatienceConfig}

--- a/core/src/test/scala/org/genivi/sota/core/rvi/PackageTransferSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/rvi/PackageTransferSpec.scala
@@ -18,7 +18,7 @@ import java.util.UUID
 import java.security.MessageDigest
 
 import org.apache.commons.codec.binary.Hex
-import org.genivi.sota.core.Generators
+import org.genivi.sota.core.{ConnectivityClient, Generators}
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.data.Vehicle
 import org.joda.time.DateTime
@@ -82,7 +82,7 @@ object ClientActor {
 /**
  * Dummy actor to simulate RVI Client in tests
  */
-class AccRviClient( clientActor: ActorRef ) extends RviClient {
+class AccRviClient( clientActor: ActorRef ) extends ConnectivityClient {
 
   def sendMessage[A](service: String, message: A, expirationDate: DateTime)
                  (implicit encoder: Encoder[A] ) : Future[Int] = {


### PR DESCRIPTION
- new env var CORE_INTERACTION_PROTOCOL which defaults to 'rvi'
- in all other cases, default to 'none' or 'default' (not yet
  implemented)
- refactor communication backend into {RVI|Default}Connectivity
- fix tests accordingly