### PR TITLE
changes to update notifications

### DIFF
--- a/core/src/main/resources/db/migration/V2__add_pkg_sigs.sql
+++ b/core/src/main/resources/db/migration/V2__add_pkg_sigs.sql
@@ -1,3 +1,22 @@
 ALTER TABLE Package
 -- Cryptographic signature of the package
-ADD signature text
+ADD signature text;
+
+ALTER TABLE UpdateRequest
+ADD signature VARCHAR(256) NOT NULL,
+ADD description text,
+ADD request_confirmation BOOLEAN NOT NULL;
+
+ALTER TABLE InstallHistory
+ADD update_request_id CHAR(36) NOT NULL,
+ADD FOREIGN KEY fk_install_history_update_request_id (update_request_id) REFERENCES UpdateRequest(update_request_id);
+
+CREATE TABLE OperationResult (
+    id CHAR(36) NOT NULL,
+    update_request_id CHAR(36) NOT NULL,
+    result_code INT NOT NULL,
+    result_text TEXT NOT NULL,
+
+    PRIMARY KEY (id),
+    FOREIGN KEY fk_operation_result_update_request_id (update_request_id) REFERENCES UpdateRequest(update_request_id)
+);

--- a/core/src/main/resources/db/migration/V3__add_upd_sig_descr_reqconf.sql
+++ b/core/src/main/resources/db/migration/V3__add_upd_sig_descr_reqconf.sql
@@ -1,4 +1,0 @@
-ALTER TABLE UpdateRequest
-ADD signature VARCHAR(256) NOT NULL,
-ADD description text,
-ADD request_confirmation BOOLEAN NOT NULL

--- a/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
@@ -5,19 +5,34 @@
 package org.genivi.sota.core.data
 
 import org.joda.time.DateTime
+import java.util.UUID
+
+/**
+ * Domain object for the update operation result
+ * @param id The unique id of operation.
+ * @param updateId Id of update this operation belongs to.
+ * @param resultCode The status of operation.
+ * @param resultText The description of operation.
+ */
+case class OperationResult(
+  id : String,
+  updateId: UUID,
+  resultCode : Int,
+  resultText : String
+)
 
 /**
  * Domain object for the install history of a VIN
  * @param id The Id in the database. Initialize to Option.None
  * @param vin The VIN that this install history belongs to
- * @param packageId The package name/version that was attempted to be installed
+ * @param updateId The Id of the update
  * @param success The outcome of the install attempt
  * @param completionTime The date the install was attempted
  */
 case class InstallHistory(
   id            : Option[Long],
   vin           : Vehicle.Vin,
-  packageId     : Package.Id,
+  updateId      : UUID,
   success       : Boolean,
   completionTime: DateTime
 )

--- a/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
@@ -11,9 +11,9 @@ import slick.driver.MySQLDriver.api._
 
 /**
  * Database mapping definition for the InstallHistory table.
- * This provides a history of package installs that have been attempted on a
- * VIN.  It records the identity of the package which was attempted to be
- * installed, the time of the attempt and whether the install was successful
+ * This provides a history of update installs that have been attempted on a
+ * VIN. It records the identity of the update, thi VIN, the time of the attempt
+ * and whether the install was successful
  */
 object InstallHistories {
 
@@ -29,15 +29,14 @@ object InstallHistories {
 
     def id             = column[Long]           ("id", O.PrimaryKey, O.AutoInc)
     def vin            = column[Vehicle.Vin]    ("vin")
-    def packageName    = column[Package.Name]   ("packageName")
-    def packageVersion = column[Package.Version]("packageVersion")
+    def updateId       = column[java.util.UUID] ("update_request_id")
     def success        = column[Boolean]        ("success")
     def completionTime = column[DateTime]       ("completionTime")
 
-    def * = (id.?, vin, packageName, packageVersion, success, completionTime).shaped <>
-      (r => InstallHistory(r._1, r._2, Package.Id(r._3, r._4), r._5, r._6),
+    def * = (id.?, vin, updateId, success, completionTime).shaped <>
+      (r => InstallHistory(r._1, r._2, r._3, r._4, r._5),
         (h: InstallHistory) =>
-          Some((h.id, h.vin, h.packageId.name, h.packageId.version, h.success, h.completionTime)))
+          Some((h.id, h.vin, h.updateId, h.success, h.completionTime)))
   }
   // scalastyle:on
 
@@ -59,10 +58,10 @@ object InstallHistories {
    * Record the outcome of a install attempt on a specific VIN. The result of
    * the install is returned from the SOTA client via RVI.
    * @param vin The VIN that the install attempt ran on
-   * @param pkgId The name/version of the package that was attempted to be installed
+   * @param updateId The Id of the update that was attempted to be installed
    * @param success Whether the install was successful
    */
-  def log(vin: Vehicle.Vin, pkgId: Package.Id, success: Boolean): DBIO[Int] =
-    installHistories += InstallHistory(None, vin, pkgId, success, DateTime.now)
+  def log(vin: Vehicle.Vin, updateId: java.util.UUID, success: Boolean): DBIO[Int] =
+    installHistories += InstallHistory(None, vin, updateId, success, DateTime.now)
 
 }

--- a/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
@@ -1,0 +1,59 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.db
+
+import java.util.UUID
+import org.genivi.sota.core.data.OperationResult
+import org.genivi.sota.db.SlickExtensions
+import scala.concurrent.ExecutionContext
+import slick.driver.MySQLDriver.api._
+
+/**
+ * Database mapping definition for the OperationResults table.
+ * These refer to the results of an UpdateRequest operation.
+ */
+object OperationResults {
+
+  import org.genivi.sota.refined.SlickRefined._
+  import Mappings._
+  import SlickExtensions._
+
+  /**
+   * Slick mapping definition for the UpdateRequests table
+   * @see {@link http://slick.typesafe.com/}
+   */
+  class OperationResultTable(tag: Tag) extends Table[OperationResult](tag, "OperationResult") {
+    def id = column[String]("id", O.PrimaryKey)
+    def updateId = column[UUID]("update_request_id")
+    def resultCode = column[Int]("result_code")
+    def resultText = column[String]("result_text")
+
+    import shapeless._
+
+    def * = (id, updateId, resultCode, resultText).shaped <>
+      (x => OperationResult(x._1, x._2, x._3, x._4),
+      (x: OperationResult) => Some((x.id, x.updateId, x.resultCode, x.resultText)))
+  }
+
+  /**
+   * Internal helper definition to accesss the SQL table
+   */
+  val all = TableQuery[OperationResultTable]
+
+  /**
+   * List all the update results that have been ever created
+   * @return A list of operation results
+   */
+  def list: DBIO[Seq[OperationResult]] = all.result
+
+  /**
+   * Add a new package update. Package updated specify a specific package at a
+   * specific version to be installed in a time window, with a given priority
+   * @param request A new update request to add
+   */
+  def persist(result: OperationResult)
+             (implicit ec: ExecutionContext): DBIO[OperationResult] = (all += result).map( _ => result)
+
+}

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -75,11 +75,14 @@ object UpdateRequests {
    */
   def list: DBIO[Seq[UpdateRequest]] = all.result
 
+  def byId(updateId: UUID) : DBIO[Option[UpdateRequest]] =
+    all.filter {_.id === updateId }.result.headOption
+
   /**
    * Add a new package update. Package updated specify a specific package at a
    * specific version to be installed in a time window, with a given priority
    * @param request A new update request to add
    */
   def persist(request: UpdateRequest)
-             (implicit ec: ExecutionContext): DBIO[UpdateRequest] = (all += request).map( _ => request)
+             (implicit ec: ExecutionContext): DBIO[Unit] = (all += request).map( _ => ())
 }

--- a/core/src/main/scala/org/genivi/sota/core/rvi/SotaServices.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/SotaServices.scala
@@ -10,11 +10,12 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import org.genivi.sota.marshalling.CirceMarshallingSupport._
-import org.genivi.sota.core.data.{Package, Vehicle}
 import io.circe.Json
-import scala.concurrent.{ExecutionContext, Future}
+import java.util.UUID
 import org.genivi.sota.core.ExternalResolverClient
+import org.genivi.sota.core.data.{Package, Vehicle}
+import org.genivi.sota.marshalling.CirceMarshallingSupport._
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
  * RVI paths for server-side services.
@@ -29,18 +30,21 @@ final case class ClientServices( start: String, abort: String, chunk: String, fi
 /**
  * RVI message from client to initiate a package download.
  */
-final case class StartDownload(vin: Vehicle.Vin, packages: List[Package.Id], services: ClientServices )
+final case class StartDownload(vin: Vehicle.Vin, update_id: UUID, services: ClientServices)
 
 /**
  * RVI parameters of generic type for a specified service name.
  */
 final case class RviParameters[T](parameters: List[T], service_name: String )
 
+final case class OperationResult(id: String, result_code: Int, result_text: String)
+
+final case class UpdateReport(update_id: UUID, operation_results: List[OperationResult])
+
 /**
  * RVI message from client to report installation of a downloaded package.
  */
-final case class InstallReport(vin: Vehicle.Vin, `package`: Package.Id, status: Boolean,
-                               description: String)
+final case class InstallReport(vin: Vehicle.Vin, update: UpdateReport)
 
 /**
  * RVI message from client to report all installed packages.

--- a/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
@@ -5,27 +5,27 @@
 package org.genivi.sota.core.rvi
 
 import akka.actor.ReceiveTimeout
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
+import akka.util.ByteString
+import io.circe.Encoder
 import java.net.URI
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.file.{Paths, StandardOpenOption}
-
-import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
-import akka.util.ByteString
-import io.circe.Encoder
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import org.apache.commons.codec.binary.Base64
 import org.genivi.sota.core.data.UpdateStatus
 import org.genivi.sota.core.data.Vehicle
 import org.genivi.sota.core.data.{Package, UpdateSpec, Vehicle}
-import org.genivi.sota.core.db.{UpdateSpecs, InstallHistories}
+import org.genivi.sota.core.db.{UpdateSpecs, InstallHistories, OperationResults, UpdateRequests}
 import org.joda.time.DateTime
+import scala.collection.immutable.Queue
+import scala.concurrent.Future
 import scala.concurrent.duration.{FiniteDuration, Duration}
+import scala.math.BigDecimal.RoundingMode
 import scala.util.control.NoStackTrace
 import slick.driver.MySQLDriver.api.Database
-
-import scala.collection.immutable.Queue
-import scala.math.BigDecimal.RoundingMode
 
 /**
  * Actor to handle events received from the RVI node.
@@ -43,17 +43,17 @@ class UpdateController(transferProtocolProps: Props) extends Actor with ActorLog
    * @param currentDownloads the map of VIN to the actor handling that vehicle
    */
   def running( currentDownloads: Map[Vehicle.Vin, ActorRef] ) : Receive = {
-    case x @ StartDownload(vin, packages, clientServices) =>
+    case x @ StartDownload(vin, updateId, clientServices) =>
       currentDownloads.get(vin) match {
         case None =>
-          log.debug(s"New transfer to vehicle $vin for $packages, count ${currentDownloads.size}")
+          log.debug(s"New transfer to vehicle $vin for update $updateId, count ${currentDownloads.size}")
           val actor = context.actorOf( transferProtocolProps )
           context.watch(actor)
           context.become( running( currentDownloads.updated( vin, actor ) ) )
           actor ! x
         case Some(x) =>
           log.warning(
-            s"There is an active transfer for vehicle $vin. Request to transfer packages $packages will be ignored." )
+            s"There is an active transfer for vehicle $vin. Request to transfer update $updateId will be ignored." )
       }
     case x @ ChunksReceived(vin, _, _) =>
       currentDownloads.get(vin).foreach( _ ! x)
@@ -90,7 +90,7 @@ object TransferProtocolActor {
   /**
    * Configuration class for creating the TransferProtocolActor actor.
    */
-  def props(db: Database, rviClient: RviClient, transferActorProps: (ClientServices, Package) => Props) =
+  def props(db: Database, rviClient: RviClient, transferActorProps: (UUID, String, Package, ClientServices) => Props) =
     Props( new TransferProtocolActor( db, rviClient, transferActorProps) )
 }
 
@@ -115,7 +115,8 @@ object UpdateEvents {
  * @param rviClient the client to the RVI node
  * @param transferActorProps the configuration class for creating the PackageTransferActor
  */
-class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorProps: (ClientServices, Package) => Props)
+class TransferProtocolActor(db: Database, rviClient: RviClient,
+                            transferActorProps: (UUID, String, Package, ClientServices) => Props)
     extends Actor with ActorLogging {
   import context.dispatcher
   import cats.syntax.show._
@@ -126,9 +127,10 @@ class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorPro
     TimeUnit.MILLISECONDS
   )
 
-  def buildTransferQueue(specs: Iterable[UpdateSpec]) : Queue[Package] = {
-    specs.foldLeft(Set.empty[Package])( (acc, x) => acc.union( x.dependencies ) ).to[Queue]
-  }
+  def buildTransferQueue(specs: Iterable[UpdateSpec]) : Queue[(UUID, String, Package)] = (for {
+    spec <- specs
+    pkg <- spec.dependencies
+  } yield (spec.request.id, spec.request.signature, pkg)).to[Queue]
 
   /**
    * Create actors to handle each transfer to the vehicle.
@@ -136,14 +138,15 @@ class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorPro
    * Terminate when all updates and dependencies are successfully transferred,
    * or when the transfer is aborted because the vehicle is not responding.
    */
-  def running(services: ClientServices, updates: Set[UpdateSpec], pending: Queue[Package],
+  def running(services: ClientServices, updates: Set[UpdateSpec], pending: Queue[(UUID, String, Package)],
               inProgress: Map[ActorRef, Package], done: Set[Package]) : Receive = {
     case akka.actor.Terminated(ref) =>
       // TODO: Handle actors terminated on errors (e.g. file exception in PackageTransferActor)
       val p = inProgress.get(ref).get
       log.debug(s"Package $p uploaded.")
-      val newInProgress = pending.headOption.map( startPackageUpload(services) )
-        .fold( inProgress - ref)( inProgress - ref + _ )
+      val newInProgress = pending.headOption.map { case (id, signature, pkg) =>
+        startPackageUpload(services)(id, signature, pkg) }
+        .fold(inProgress - ref)(inProgress - ref + _)
       if( newInProgress.isEmpty ) {
         log.debug( s"All packages uploaded." )
         context.setReceiveTimeout(installTimeout)
@@ -152,29 +155,30 @@ class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorPro
         }
       } else {
         val finishedPackageTransfers = done + p
-        val (finishedUpdates, unfinishedUpdates) = updates.span(_.dependencies.diff( finishedPackageTransfers ).isEmpty)
+        val (finishedUpdates, unfinishedUpdates) = updates.span(_.dependencies.diff(finishedPackageTransfers).isEmpty)
         context.become(
           running( services, unfinishedUpdates, if(pending.isEmpty) pending else pending.tail,
                    newInProgress, finishedPackageTransfers) )
       }
 
-    case x @ ChunksReceived(vin, p, _) =>
-      inProgress.find( _._2.id == p).foreach( _._1 ! x)
+    case x @ ChunksReceived(vin, updateId, _) =>
+      inProgress.find( _._2.id == updateId).foreach( _._1 ! x)
 
-    case r @ InstallReport(vin, packageId, success, msg) =>
+    case r @ InstallReport(vin, update) =>
       context.system.eventStream.publish( UpdateEvents.InstallReportReceived(r) )
-      log.debug(s"Install report received from $vin: ${packageId.show} installed $success, $msg")
-      updates.find( _.request.packageId === packageId ).foreach { finishedSpec =>
-        val pendingSpecs = updates - finishedSpec
-        db.run( UpdateSpecs.setStatus( finishedSpec, if( success ) UpdateStatus.Finished  else UpdateStatus.Failed ) )
-        db.run( InstallHistories.log(vin, packageId, success) )
-        if( pendingSpecs.isEmpty ) {
-          log.debug( "All installation reports received." )
+      log.debug(s"Install report received from $vin: ${update.update_id} installed with ${update.operation_results}")
+      updates.find(_.request.id == update.update_id).headOption match {
+        case Some(spec) => {
+          db.run(UpdateSpecs.setStatus(spec, UpdateStatus.Finished))
+          update.operation_results.foreach { r: OperationResult =>
+            db.run(OperationResults.persist(org.genivi.sota.core.data.OperationResult(
+              r.id, update.update_id, r.result_code, r.result_text)))
+          }
+          db.run(InstallHistories.log(vin, update.update_id, true))
           rviClient.sendMessage(services.getpackages, io.circe.Json.Empty, ttl())
           context.stop( self )
-        } else {
-          context.become(running( services, pendingSpecs, pending, inProgress, done ))
         }
+        case None => log.error(s"Update ${update.update_id} for corresponding install report does not exist!")
       }
 
     case ReceiveTimeout =>
@@ -195,16 +199,20 @@ class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorPro
     DateTime.now + 5.minutes
   }
 
-  def startPackageUpload( services: ClientServices)( p: Package ) : (ActorRef, Package) = {
-    val ref = context.actorOf( transferActorProps(services, p), s"${p.id.name.get}-${p.id.version.get}")
+  def startPackageUpload(services: ClientServices)
+                        (updateId: UUID,
+                         signature: String,
+                         pkg: Package): (ActorRef, Package) = {
+    val ref = context.actorOf(transferActorProps(updateId, signature, pkg, services), updateId.toString)
     context.watch(ref)
-    ref -> p
+    ref -> pkg
   }
 
   def loadSpecs(services: ClientServices) : Receive = {
     case TransferProtocolActor.Specs(values) =>
       val todo = buildTransferQueue(values)
-      val workers : Map[ActorRef, Package] = todo.take(3).map( startPackageUpload(services) ).toMap
+      val workers : Map[ActorRef, Package] =
+        todo.take(3).map { case (id, signature, pkg) => startPackageUpload(services)(id, signature, pkg) }.toMap
       context become running( services, values.toSet, todo.drop(3), workers, Set.empty )
 
     case Status.Failure(t) =>
@@ -216,16 +224,16 @@ class TransferProtocolActor(db: Database, rviClient: RviClient, transferActorPro
    * Entry point to this actor when the vehicle initiates a download.
    */
   override def receive : Receive = {
-    case StartDownload(vin, packages, services) =>
-      log.debug(s"$vin requested packages $packages")
+    case StartDownload(vin, updateId, services) =>
+      log.debug(s"$vin requested update $updateId")
       import akka.pattern.pipe
-      db.run( UpdateSpecs.load(vin, packages.toSet) ).map(TransferProtocolActor.Specs.apply) pipeTo self
+      db.run(UpdateSpecs.load(vin, updateId)).map(TransferProtocolActor.Specs.apply) pipeTo self
       context become loadSpecs(services)
   }
 
 }
 
-case class StartDownloadMessage( `package`: Package.Id, checksum: String, chunkscount: Int )
+case class StartDownloadMessage(update_id: UUID, checksum: String, chunkscount: Int)
 
 object StartDownloadMessage {
 
@@ -236,9 +244,9 @@ object StartDownloadMessage {
 
 }
 
-case class ChunksReceived( vin: Vehicle.Vin, `package`: Package.Id, chunks: List[Int] )
+case class ChunksReceived(vin: Vehicle.Vin, update_id: UUID, chunks: List[Int])
 
-case class PackageChunk( `package`: Package.Id, bytes: ByteString, index: Int)
+case class PackageChunk(update_id: UUID, bytes: ByteString, index: Int)
 
 object PackageChunk {
 
@@ -252,7 +260,7 @@ object PackageChunk {
 
 }
 
-case class Finish(`package`: Package.Id )
+case class Finish(update_id: UUID, signature: String)
 
 object Finish {
 
@@ -268,10 +276,15 @@ case object UploadAborted
 /**
  * Actor to handle transferring chunks to a vehicle.
  *
+ * @param updateId Unique Id of the update.
  * @param pckg the package to transfer
  * @param services the service paths available on the vehicle
  */
-class PackageTransferActor( pckg: Package, services: ClientServices, rviClient: RviClient )
+class PackageTransferActor(updateId: UUID,
+                           signature: String,
+                           pckg: Package,
+                           services: ClientServices,
+                           rviClient: RviClient)
     extends Actor with ActorLogging {
 
   import io.circe.generic.auto._
@@ -301,18 +314,18 @@ class PackageTransferActor( pckg: Package, services: ClientServices, rviClient: 
     buffer.clear()
     val bytesRead = channel.read( buffer )
     buffer.flip()
-    rviClient.sendMessage( services.chunk, PackageChunk( pckg.id,  ByteString( buffer ), index), ttl() )
+    rviClient.sendMessage(services.chunk, PackageChunk(updateId, ByteString(buffer), index), ttl())
     context.setReceiveTimeout( ackTimeout )
   }
 
   def finish() : Unit = {
-    rviClient.sendMessage( services.finish, Finish(pckg.id), ttl() )
+    rviClient.sendMessage(services.finish, Finish(updateId, signature), ttl())
     context stop self
   }
 
   override def preStart() : Unit = {
     log.debug(s"Starting transfer of the package $pckg. Chunk size: $chunkSize, chunks to transfer: $lastIndex")
-    rviClient.sendMessage( services.start, StartDownloadMessage(pckg.id, pckg.checkSum, lastIndex), ttl() )
+    rviClient.sendMessage( services.start, StartDownloadMessage(updateId, pckg.checkSum, lastIndex), ttl() )
   }
 
   val maxAttempts : Int = 5
@@ -372,7 +385,7 @@ object PackageTransferActor {
   /**
    * Configuration class for creating PackageTransferActor.
    */
-  def props( rviClient: RviClient )( services: ClientServices, pckg: Package) : Props =
-    Props( new PackageTransferActor(pckg, services, rviClient) )
+  def props(rviClient: RviClient)(updateId: UUID, signature: String, pckg: Package, services: ClientServices): Props =
+    Props(new PackageTransferActor(updateId, signature, pckg, services, rviClient))
 
 }

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -84,11 +84,11 @@ object SotaClient {
     val vin = refineMV[Vehicle.ValidVin]("V1234567890123456")
 
     override def receive = {
-      case UpdateNotification(packages, services ) =>
+      case UpdateNotification(update, services ) =>
         log.debug( "Update notification received." )
         rviClient.sendMessage(
           services.start,
-          StartDownload(vin, packages.map(_.`package`).toList, clientServices),
+          StartDownload(vin, update.update_id, clientServices),
           ttl())
       case m => log.debug(s"Not supported yet: $m")
     }


### PR DESCRIPTION
- substitute packageId for updateId when dealing with update notifications;
- pass updateId, along with packageId(necessary?), signature, and requestConfirmation flag to SOTA client
- changed tests accordingly
- added schema v4

depends/supersedes on #292 