### PR TITLE
New endpoint to receive status about packages installed

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdate.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdate.scala
@@ -1,0 +1,16 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.transfer
+
+import org.genivi.sota.core.ExternalResolverClient
+import org.genivi.sota.core.rvi.InstalledPackages
+
+import scala.concurrent.Future
+
+class InstalledPackagesUpdate(resolverClient: ExternalResolverClient) {
+
+  def update(installedPackages: InstalledPackages): Future[Unit] =
+    resolverClient.setInstalledPackages(installedPackages.vin, installedPackages.packages)
+}

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -1,0 +1,27 @@
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpResponse, Uri}
+import akka.http.scaladsl.util.FastFuture
+import akka.stream.ActorMaterializer
+import io.circe.Json
+import org.genivi.sota.core.data.{Package, Vehicle}
+import org.genivi.sota.core.rvi.InstalledPackages
+
+import scala.concurrent.Future
+
+class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterializer) extends DefaultExternalResolverClient(Uri.Empty, Uri.Empty, Uri.Empty, Uri.Empty)
+{
+  val installedPackages = scala.collection.mutable.Queue.empty[InstalledPackages]
+
+  override def setInstalledPackages(vin: Vehicle.Vin, json: Json): Future[Unit] = {
+    installedPackages.enqueue(InstalledPackages(vin, json))
+    Future.successful(())
+  }
+
+  override def resolve(packageId: Package.Id): Future[Map[Vehicle, Set[Package.Id]]] = ???
+
+  override def handlePutResponse(futureResponse: Future[HttpResponse]): Future[Unit] = ???
+
+  override def putPackage(packageId: Package.Id, description: Option[String], vendor: Option[String]): Future[Unit] = ???
+}

--- a/core/src/test/scala/org/genivi/sota/core/VehicleResourceWordSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/VehicleResourceWordSpec.scala
@@ -37,7 +37,7 @@ class VinResourceWordSpec extends WordSpec
   val serverTransport = HttpTransport( rviUri )
   implicit val rviClient = new JsonRpcRviClient( serverTransport.requestTransport, system.dispatcher)
 
-  lazy val service = new VehiclesResource(db, rviClient)
+  lazy val service = new VehiclesResource(db, rviClient, new FakeExternalResolver())
 
   val testVins = List("12345678901234500", "1234567WW0123AAAA", "123456789012345WW")
 

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -107,7 +107,7 @@ object SotaClient {
                 (implicit system: ActorSystem, mat: ActorMaterializer) : Future[Route] = {
     import system.dispatcher
 
-    val rviUri = Uri("http://127.0.0.1:8901")
+    val rviUri = Uri(system.settings.config.getString( "rvi.endpoint" ))
     implicit val clientTransport = HttpTransport( rviUri ).requestTransport
     val rviClient = new JsonRpcRviClient( clientTransport, system.dispatcher )
 


### PR DESCRIPTION
New endpoint to receive status about packages installed in the client. The request will be forwarded to the external resolver

- `PUT /vehicles/:vin/packages` with a `InstalledPackages` body