### PR TITLE
optional database migration on startup

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -75,6 +75,8 @@ database = {
     password = ${?CORE_DB_PASSWORD}
   }
   numThreads = 10
+  migrate = false
+  migrate = ${?CORE_DB_MIGRATE}
 }
 
 test-database = ${database}

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -33,6 +33,18 @@ object Boot extends App with DatabaseConfig {
   implicit val log = Logging(system, "boot")
   val config = system.settings.config
 
+  // Database migrations
+  if (config.getBoolean("database.migrate")) {
+    val url = config.getString("database.url")
+    val user = config.getString("database.properties.user")
+    val password = config.getString("database.properties.password")
+
+    import org.flywaydb.core.Flyway
+    val flyway = new Flyway
+    flyway.setDataSource(url, user, password)
+    flyway.migrate()
+  }
+
   val externalResolverClient = new DefaultExternalResolverClient(
     Uri(config.getString("resolver.baseUri")),
     Uri(config.getString("resolver.resolveUri")),

--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -18,6 +18,8 @@ database {
   numThreads = 10
   connectionTimeout = 5000
   validationTimeout = 5000
+  migrate = false
+  migrate = ${?RESOLVER_DB_MIGRATE}
 }
 
 test-database = ${database}

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -47,8 +47,21 @@ object Boot extends App {
   implicit val exec         = system.dispatcher
   implicit val log          = Logging(system, "boot")
   implicit val db           = Database.forConfig("database")
+  val config = system.settings.config
 
   log.info(org.genivi.sota.resolver.BuildInfo.toString)
+
+  // Database migrations
+  if (config.getBoolean("database.migrate")) {
+    val url = config.getString("database.url")
+    val user = config.getString("database.properties.user")
+    val password = config.getString("database.properties.password")
+
+    import org.flywaydb.core.Flyway
+    val flyway = new Flyway
+    flyway.setDataSource(url, user, password)
+    flyway.migrate()
+  }
 
   val route         = new Routing
   val host          = system.settings.config.getString("server.host")

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -59,7 +59,7 @@ object SotaBuild extends Build {
 
   lazy val externalResolver = Project(id = "resolver", base = file("external-resolver"))
     .settings( commonSettings ++ Migrations.settings ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.ParserCombinators,
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.ParserCombinators :+ Dependencies.Flyway,
       parallelExecution in Test := false,
       dockerExposedPorts := Seq(8081),
       flywayUrl := sys.env.get("RESOLVER_DB_URL").orElse( sys.props.get("resolver.db.url") ).getOrElse("jdbc:mysql://localhost:3306/sota_resolver"),
@@ -72,7 +72,7 @@ object SotaBuild extends Build {
 
   lazy val core = Project(id = "core", base = file("core"))
     .settings( commonSettings ++ Migrations.settings ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.NscalaTime :+ Dependencies.Scalaz,
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.NscalaTime :+ Dependencies.Scalaz :+ Dependencies.Flyway,
       testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi"),
       testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi"),
       parallelExecution in Test := false,
@@ -161,7 +161,7 @@ object Dependencies {
 
   lazy val ScalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.4"
 
-  lazy val Flyway = "org.flywaydb" % "flyway-core" % "3.2.1" % "test"
+  lazy val Flyway = "org.flywaydb" % "flyway-core" % "3.2.1"
 
   lazy val TestFrameworks = Seq( ScalaTest, ScalaCheck )
 


### PR DESCRIPTION
- new env vars CORE_DB_MIGRATE and RESOLVER_DB_MIGRATE which default to
  false; when set, tries to migrate the current db schema to the newest
  version.
- does not drop schemas