### PR TITLE
Implement new http endpoints to allow client to update and download packages

### DIFF
--- a/common/src/main/scala/org/genivi/sota/db/SlickExtensions.scala
+++ b/common/src/main/scala/org/genivi/sota/db/SlickExtensions.scala
@@ -9,6 +9,10 @@ import java.util.UUID
 
 import akka.http.scaladsl.model.Uri
 import org.joda.time.DateTime
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.Uuid
+
 import slick.ast.{Node, TypedType}
 import slick.driver.MySQLDriver.api._
 import slick.lifted.Rep
@@ -43,4 +47,7 @@ object SlickExtensions {
   import scala.language.implicitConversions
 
   implicit def mappedColumnExtensions(c: Rep[_]) : MappedExtensionMethods = new MappedExtensionMethods(c.toNode)
+
+  implicit def uuidToJava(refined: Refined[String, Uuid]): Rep[UUID] =
+    UUID.fromString(refined.get).bind
 }

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -84,7 +84,7 @@ object Boot extends App with DatabaseConfig {
       Http().bindAndHandle(routes(notifier), host, port)
       val hostVehicles = config.getString("server.hostVehicles")
       val portVehicles = config.getInt("server.portVehicles")
-      val routesVehicles = new VehicleService(db).route
+      val routesVehicles = new VehicleService(db, externalResolverClient).route
       Http().bindAndHandle(routesVehicles, hostVehicles, portVehicles)
       FastFuture.successful(ServerServices("","","",""))
     }

--- a/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
@@ -84,7 +84,7 @@ class UpdateService(notifier: UpdateNotifier)
   def persistRequest(request: UpdateRequest, updateSpecs: Set[UpdateSpec])
                     (implicit db: Database, ec: ExecutionContext) : Future[Unit] = {
     db.run(
-      DBIO.seq( UpdateRequests.persist(request) +: updateSpecs.map( UpdateSpecs.persist ).toArray: _*)).map( _ => ()
+      DBIO.seq(UpdateRequests.persist(request) +: updateSpecs.map( UpdateSpecs.persist ).toArray: _*)).map( _ => ()
     )
   }
 

--- a/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
@@ -7,13 +7,19 @@ package org.genivi.sota.core
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.{HttpResponse}
+import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.server.{Directives, ExceptionHandler}
 import akka.stream.ActorMaterializer
+import eu.timepit.refined.string.Uuid
+import org.genivi.sota.core.rvi.InstallReport
+import org.genivi.sota.core.transfer.{InstalledPackagesUpdate, PackageDownloadProcess}
+import org.genivi.sota.data.PackageId
 import slick.driver.MySQLDriver.api.Database
+import io.circe.generic.auto._
+import org.genivi.sota.rest.Validation.refined
+import org.genivi.sota.marshalling.CirceMarshallingSupport._
 
-
-class VehicleService(db : Database)
+class VehicleService(db : Database, resolverClient: ExternalResolverClient)
                     (implicit system: ActorSystem, mat: ActorMaterializer,
                      connectivity: Connectivity) extends Directives {
   implicit val log = Logging(system, "vehicleservice")
@@ -24,17 +30,52 @@ class VehicleService(db : Database)
   val exceptionHandler = ExceptionHandler {
     case e: Throwable =>
       extractUri { uri =>
-        log.error(s"Request to $uri errored: $e")
-        val entity = obj("error" -> string(e.getMessage()))
+        log.error(s"Request to $uri failed: $e")
+        val entity = obj("error" -> string(e.getMessage))
         complete(HttpResponse(InternalServerError, entity = entity.toString()))
       }
   }
-  val vehicles = new VehiclesResource(db, connectivity.client)
 
-  val route = pathPrefix("api" / "v1") {
+  val vehicles = new VehiclesResource(db, connectivity.client, resolverClient)
+
+  val extractUuid = refined[Uuid](Slash ~ Segment)
+
+  implicit val ec = system.dispatcher
+  implicit val _db = db
+
+  val route = pathPrefix("api" / "v1" / "vehicles") {
     handleExceptions(exceptionHandler) {
-       vehicles.route
+      vehicles.route ~
+        WebService.extractVin { vin ⇒
+          pathPrefix("updates") {
+            (pathEnd & post) {
+              entity(as[List[PackageId]]) { ids =>
+                val f = InstalledPackagesUpdate
+                  .update(vin, ids, resolverClient)
+                  .map(_ => NoContent)
+
+                complete(f)
+              }
+            } ~
+              (pathEnd & get) {
+                val responseF = new PackageDownloadProcess(db).buildClientPendingIdsResponse(vin)
+                complete(responseF)
+              } ~
+              (get & withRangeSupport & extractUuid & path("download")) { uuid =>
+                val responseF = new PackageDownloadProcess(db).buildClientDownloadResponse(uuid)
+                complete(responseF)
+              } ~
+              (post & extractUuid) { uuid =>
+                entity(as[InstallReport]) { report =>
+                  val responseF =
+                    InstalledPackagesUpdate
+                      .buildReportInstallResponse(report.vin, report.update_report)
+
+                  complete(responseF)
+                }
+              }
+          }
+        }
     }
   }
-
 }

--- a/core/src/main/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdate.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdate.scala
@@ -1,0 +1,80 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.transfer
+
+
+import java.util.UUID
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import io.circe.syntax._
+import org.genivi.sota.data.{PackageId, Vehicle}
+import org.genivi.sota.core.ExternalResolverClient
+import org.genivi.sota.core.data._
+import org.genivi.sota.core.db.{InstallHistories, OperationResults, UpdateRequests, UpdateSpecs}
+import org.genivi.sota.db.SlickExtensions
+import slick.dbio.DBIO
+import slick.driver.MySQLDriver.api._
+import org.genivi.sota.core.db.UpdateSpecs._
+import org.genivi.sota.core.rvi.UpdateReport
+
+import scala.concurrent.{ExecutionContext, Future}
+import org.genivi.sota.refined.SlickRefined._
+
+
+object InstalledPackagesUpdate {
+  import SlickExtensions._
+
+  case class UpdateSpecNotFound(msg: String) extends Exception(msg)
+
+  def update(vin: Vehicle.Vin, packageIds: List[PackageId], resolverClient: ExternalResolverClient): Future[Unit] = {
+    val ids = packageIds.asJson
+    resolverClient.setInstalledPackages(vin, ids)
+  }
+
+  def buildReportInstallResponse(vin: Vehicle.Vin, updateReport: UpdateReport)
+                                (implicit ec: ExecutionContext, db: Database): Future[HttpResponse] = {
+    reportInstall(vin, updateReport) map { _ =>
+      HttpResponse(StatusCodes.NoContent)
+    } recover { case t: UpdateSpecNotFound =>
+      HttpResponse(StatusCodes.NotFound, entity = t.getMessage)
+    }
+  }
+
+  def reportInstall(vin: Vehicle.Vin, updateReport: UpdateReport)
+                   (implicit ec: ExecutionContext, db: Database): Future[UpdateSpec] = {
+    val writeResultsIO = updateReport
+      .operation_results
+      .map(r => org.genivi.sota.core.data.OperationResult(r.id, updateReport.update_id, r.result_code, r.result_text))
+      .map(r => OperationResults.persist(r))
+
+    val dbIO = for {
+      spec <- findUpdateSpecFor(vin, updateReport.update_id)
+      _ <- DBIO.sequence(writeResultsIO)
+      _ <- UpdateSpecs.setStatus(spec, UpdateStatus.Finished)
+      _ <- InstallHistories.log(vin, spec.request.id, spec.request.packageId, success = true)
+    } yield spec.copy(status = UpdateStatus.Finished)
+
+    db.run(dbIO)
+  }
+
+  def findUpdateSpecFor(vin: Vehicle.Vin, updateRequestId: UUID)
+                       (implicit ec: ExecutionContext, db: Database): DBIO[UpdateSpec] = {
+    updateSpecs
+      .filter(_.vin === vin)
+      .filter(_.requestId === updateRequestId)
+      .join(updateRequests).on(_.requestId === _.id)
+      .result
+      .headOption
+      .flatMap {
+        case Some(((uuid, updateVin, status), updateRequest)) =>
+          val spec = UpdateSpec(updateRequest, updateVin, status, Set.empty[Package])
+          DBIO.successful(spec)
+        case None =>
+          DBIO.failed(
+            UpdateSpecNotFound(s"Could not find an update request with id $updateRequestId for vin ${vin.get}")
+          )
+      }
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
@@ -1,0 +1,77 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.transfer
+
+import java.io.File
+import java.net.URI
+import java.util.UUID
+
+import akka.http.scaladsl.model._
+import akka.stream.io.SynchronousFileSource
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.Uuid
+import org.genivi.sota.core.data.{Package, UpdateStatus}
+import org.genivi.sota.core.db.Packages
+import org.genivi.sota.core.db.UpdateSpecs._
+import org.genivi.sota.data.Vehicle
+import org.genivi.sota.db.SlickExtensions
+import org.genivi.sota.refined.SlickRefined._
+import slick.driver.MySQLDriver.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.implicitConversions
+
+
+class PackageDownloadProcess(db: Database) {
+  import SlickExtensions._
+
+  def buildClientDownloadResponse(uuid: Refined[String, Uuid])(implicit ec: ExecutionContext): Future[HttpResponse] = {
+    val availablePackageIO = findForDownload(uuid)
+
+    db.run(availablePackageIO).map {
+      case Some(packageModel) =>
+        val entity = fileEntity(packageModel)
+        HttpResponse(StatusCodes.OK, entity = entity)
+      case None =>
+        HttpResponse(StatusCodes.NotFound, entity = "Package not found")
+    }
+  }
+
+  def buildClientPendingIdsResponse(vin: Vehicle.Vin)
+                                   (implicit ec: ExecutionContext) : Future[Seq[UUID]] = {
+    db.run(findPendingPackageIdsFor(vin))
+  }
+
+  private def findPendingPackageIdsFor(vin: Vehicle.Vin)
+                              (implicit ec: ExecutionContext) : DBIO[Seq[UUID]] = {
+    updateSpecs
+      .filter(r => r.vin === vin)
+      .filter(_.status.inSet(List(UpdateStatus.InFlight, UpdateStatus.Pending)))
+      .map(_.requestId)
+      .result
+  }
+
+  private def findPackagesWith(updateRequestId: Refined[String, Uuid]): DBIO[Seq[Package]] = {
+    updateRequests
+      .filter(_.id === updateRequestId)
+      .join(Packages.packages)
+      .on((updateRequest, packageM) =>
+        packageM.name === updateRequest.packageName && packageM.version === updateRequest.packageVersion)
+      .map { case (_, packageM) => packageM }
+      .result
+  }
+
+  private def findForDownload(updateRequestId: Refined[String, Uuid])
+                             (implicit ec: ExecutionContext): DBIO[Option[Package]] = {
+    findPackagesWith(updateRequestId).map(_.headOption)
+  }
+
+  private def fileEntity(packageModel: Package): UniversalEntity = {
+    val file = new File(new URI(packageModel.uri.toString()))
+    val size = file.length()
+    val source = SynchronousFileSource(file)
+    HttpEntity(MediaTypes.`application/octet-stream`, size, source)
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -1,0 +1,26 @@
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpResponse, Uri}
+import akka.stream.ActorMaterializer
+import io.circe.Json
+import org.genivi.sota.data.{PackageId, Vehicle}
+
+import scala.concurrent.Future
+
+class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterializer) extends DefaultExternalResolverClient(Uri.Empty, Uri.Empty, Uri.Empty, Uri.Empty)
+{
+  val installedPackages = scala.collection.mutable.Queue.empty[PackageId]
+
+  override def setInstalledPackages(vin: Vehicle.Vin, json: Json): Future[Unit] = {
+    val ids = json.as[List[PackageId]].getOrElse(List.empty)
+    installedPackages.enqueue(ids:_*)
+    Future.successful(())
+  }
+
+  override def resolve(packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = ???
+
+  override def handlePutResponse(futureResponse: Future[HttpResponse]): Future[Unit] = ???
+
+  override def putPackage(packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = ???
+}

--- a/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
@@ -6,6 +6,16 @@ package org.genivi.sota.core
 
 import com.typesafe.config.ConfigFactory
 import org.flywaydb.core.Flyway
+import org.genivi.sota.core.data.{Package, UpdateSpec}
+import org.genivi.sota.core.db.{Packages, UpdateRequests, UpdateSpecs, Vehicles}
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import scala.concurrent.ExecutionContext
+import slick.driver.MySQLDriver.api._
+import org.genivi.sota.data.Vehicle
+
+import scala.concurrent.Future
+import org.genivi.sota.db.SlickExtensions
 
 /*
  * Helper object to configure test database for specs
@@ -23,5 +33,43 @@ object TestDatabase {
     flyway.setLocations("classpath:db.migration")
     flyway.clean()
     flyway.migrate()
+  }
+}
+
+trait DatabaseSpec extends BeforeAndAfterAll {
+  self: Suite =>
+
+  private val databaseId = "test-database"
+
+  lazy val db = Database.forConfig(databaseId)
+
+  override def beforeAll() {
+    TestDatabase.resetDatabase(databaseId)
+    super.beforeAll()
+  }
+
+  override def afterAll() {
+    db.close()
+    super.afterAll()
+  }
+}
+
+trait VehicleDatabaseSpec {
+  self: DatabaseSpec =>
+
+  import Generators._
+  import SlickExtensions._
+
+  def createUpdateSpec()(implicit ec: ExecutionContext): Future[(Package, Vehicle, UpdateSpec)] = {
+    val (packageModel, vehicle, updateSpec) = updateSpecGen.sample.get
+
+    val dbIO = DBIO.seq(
+      Packages.create(packageModel),
+      Vehicles.create(vehicle),
+      UpdateRequests.persist(updateSpec.request),
+      UpdateSpecs.persist(updateSpec)
+    )
+
+    db.run(dbIO).map(_ => (packageModel, vehicle, updateSpec))
   }
 }

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
@@ -56,6 +56,7 @@ class UpdateRequestSpec extends PropSpec with PropertyChecks with Matchers with 
   property("Update requests can be listed")  {
     new Service() {
       forAll(Gen.listOf(updateRequestGen(PackageIdGen))) { (requests: Seq[UpdateRequest]) =>
+        // TODO: I don't think this test is running, we just create a future and never wait for it's result
         Future.sequence(requests.map(r => db.run(UpdateRequests.persist(r)))).map { _ =>
           Get( Uri(path = UpdatesPath) ) ~> resource.route ~> check {
             status shouldBe StatusCodes.OK

--- a/core/src/test/scala/org/genivi/sota/core/VehicleResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/VehicleResourceSpec.scala
@@ -4,53 +4,64 @@
  */
 package org.genivi.sota.core
 
+import akka.http.scaladsl.unmarshalling.Unmarshaller._
 import akka.http.scaladsl.model.Uri.Path
-import akka.http.scaladsl.model.{StatusCodes, Uri}
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
+import org.genivi.sota.data.{PackageId, Vehicle, VehicleGenerators}
+import org.genivi.sota.core.rvi._
+import org.genivi.sota.core.db.{Packages, UpdateRequests, UpdateSpecs, Vehicles}
+import io.circe.syntax._
+import org.genivi.sota.core.db._
 import org.genivi.sota.marshalling.CirceMarshallingSupport
-import CirceMarshallingSupport._
-import org.genivi.sota.core.rvi.JsonRpcRviClient
 import org.genivi.sota.core.jsonrpc.HttpTransport
-import org.genivi.sota.data.Vehicle
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest._
+import slick.driver.MySQLDriver.api._
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
-import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
-import slick.driver.MySQLDriver.api._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server._
+import org.genivi.sota.core.data.{UpdateSpec, UpdateStatus}
+import org.genivi.sota.core.transfer.InstalledPackagesUpdate
+import org.scalatest.time.{Millis, Seconds, Span}
 
 /**
  * Spec tests for vehicle REST actions
  */
 class VehicleResourceSpec extends PropSpec with PropertyChecks
-    with Matchers
-    with ScalatestRouteTest
-    with BeforeAndAfterAll {
+  with Matchers
+  with ScalatestRouteTest
+  with ScalaFutures
+  with DatabaseSpec
+  with VehicleDatabaseSpec {
 
-  val databaseName = "test-database"
-  val db = Database.forConfig(databaseName)
+  import CirceMarshallingSupport._
+  import Generators._
+  import org.genivi.sota.data.VehicleGenerators._
+  import org.genivi.sota.data.PackageIdGenerators._
 
   val rviUri = Uri(system.settings.config.getString( "rvi.endpoint" ))
   val serverTransport = HttpTransport( rviUri )
   implicit val rviClient = new JsonRpcRviClient( serverTransport.requestTransport, system.dispatcher)
 
-  lazy val service = new VehiclesResource(db, rviClient)
+  val fakeResolver = new FakeExternalResolver()
 
-  override def beforeAll {
-    TestDatabase.resetDatabase( databaseName )
-  }
+  lazy val service = new VehiclesResource(db, rviClient, fakeResolver)
 
   val BasePath = Path("/vehicles")
+
+  implicit val patience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  implicit val _db = db
 
   def resourceUri( pathSuffix : String ) : Uri = {
     Uri.Empty.withPath(BasePath / pathSuffix)
   }
 
   def vehicleUri(vin: Vehicle.Vin)  = Uri.Empty.withPath( BasePath / vin.get )
-
-  import Generators._
-  import org.genivi.sota.data.VehicleGenerators._
 
   property( "create new vehicle" ) {
     forAll { (vehicle: Vehicle) =>
@@ -93,10 +104,4 @@ class VehicleResourceSpec extends PropSpec with PropertyChecks
       }
     }
   }
-
-  override def afterAll() {
-    system.terminate()
-    db.close()
-  }
-
 }

--- a/core/src/test/scala/org/genivi/sota/core/VehicleResourceWordSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/VehicleResourceWordSpec.scala
@@ -38,7 +38,7 @@ class VinResourceWordSpec extends WordSpec
   val serverTransport = HttpTransport( rviUri )
   implicit val rviClient = new JsonRpcRviClient( serverTransport.requestTransport, system.dispatcher)
 
-  lazy val service = new VehiclesResource(db, rviClient)
+  lazy val service = new VehiclesResource(db, rviClient, new FakeExternalResolver())
 
   val testVins = List("12345678901234500", "1234567WW0123AAAA", "123456789012345WW")
 

--- a/core/src/test/scala/org/genivi/sota/core/VehicleServiceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/VehicleServiceSpec.scala
@@ -1,0 +1,133 @@
+package org.genivi.sota.core
+
+import akka.http.scaladsl.unmarshalling.Unmarshaller._
+import java.util.UUID
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.genivi.sota.core.rvi.{InstallReport, OperationResult, UpdateReport}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSuite, Inspectors, ShouldMatchers}
+import org.genivi.sota.data.VehicleGenerators._
+import org.genivi.sota.data.PackageIdGenerators._
+import org.scalacheck.Gen
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.genivi.sota.core.data.UpdateStatus
+import org.genivi.sota.core.db.{InstallHistories, Vehicles}
+import org.genivi.sota.core.transfer.InstalledPackagesUpdate
+import org.genivi.sota.marshalling.CirceMarshallingSupport._
+import io.circe.generic.auto._
+
+class VehicleServiceSpec extends FunSuite
+  with ShouldMatchers
+  with ScalatestRouteTest
+  with ScalaFutures
+  with DatabaseSpec
+  with Inspectors
+  with VehicleDatabaseSpec {
+
+  val fakeResolver = new FakeExternalResolver()
+
+  implicit val connectivity = DefaultConnectivity
+
+  lazy val service = new VehicleService(db, fakeResolver)
+
+  val BasePath = Path("/api/v1/vehicles")
+
+  implicit val patience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  implicit val _db = db
+
+  test("install updates are forwarded to external resolver") {
+    val fakeResolverClient = new FakeExternalResolver()
+    val vehiclesResource = new VehicleService(db, fakeResolverClient)
+
+    val vin = genVehicle.sample.get.vin
+    val packageIds = Gen.listOf(genPackageId).sample.get
+
+    val uri = Uri.Empty.withPath(BasePath / vin.get / "updates")
+
+    Post(uri, packageIds) ~> vehiclesResource.route ~> check {
+      status shouldBe StatusCodes.NoContent
+
+      packageIds.foreach { p =>
+        fakeResolverClient.installedPackages.toList should contain(p)
+      }
+    }
+  }
+
+  test("GET to download file returns the file contents") {
+    whenReady(createUpdateSpec()) { case (packageModel, vehicle, updateSpec) =>
+      val url = Uri.Empty.withPath(BasePath / vehicle.vin.get / "updates" / updateSpec.request.id.toString / "download")
+      Get(url) ~> service.route ~> check {
+        status shouldBe StatusCodes.OK
+
+        responseEntity.contentLengthOption should contain(packageModel.size)
+      }
+    }
+  }
+
+  test("GET returns 404 if there is no package with the given id") {
+    val vehicle = genVehicle.sample.get
+    val uuid = UUID.randomUUID()
+    val url = Uri.Empty.withPath(BasePath / vehicle.vin.get / "updates" / uuid.toString / "download")
+
+    Get(url) ~> service.route ~> check {
+      status shouldBe StatusCodes.NotFound
+      responseAs[String] should include("Package not found")
+    }
+  }
+
+  test("GET update requests for a vehicle returns a list of UUIDS") {
+    whenReady(createUpdateSpec()) { case (_, vehicle, updateSpec) =>
+      val url = Uri.Empty.withPath(BasePath / vehicle.vin.get / "updates")
+
+      Get(url) ~> service.route ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[List[UUID]] shouldNot be(empty)
+        responseAs[List[UUID]] should be(List(updateSpec.request.id))
+      }
+    }
+  }
+
+  test("POST an update report updates an UpdateSpec status") {
+    whenReady(createUpdateSpec()) { case (_, vehicle, updateSpec) =>
+      val url = Uri.Empty.withPath(BasePath / vehicle.vin.get / "updates" / updateSpec.request.id.toString)
+      val result = OperationResult("opid", 1, "some result")
+      val updateReport = UpdateReport(updateSpec.request.id, List(result))
+      val installReport = InstallReport(vehicle.vin, updateReport)
+
+      Post(url, installReport) ~> service.route ~> check {
+        status shouldBe StatusCodes.NoContent
+
+        val dbIO = for {
+          updateSpec <- InstalledPackagesUpdate.findUpdateSpecFor(vehicle.vin, updateSpec.request.id)
+          histories <- InstallHistories.list(vehicle.vin)
+        } yield (updateSpec, histories.last)
+
+        whenReady(db.run(dbIO)) { case (updatedSpec, lastHistory) =>
+          updatedSpec.status shouldBe UpdateStatus.Finished
+          lastHistory.success shouldBe true
+        }
+      }
+    }
+  }
+
+  test("Returns 404 if package does not exist") {
+    val vehicle = genVehicle.sample.get
+    val f = db.run(Vehicles.create(vehicle))
+
+    whenReady(f) { vin =>
+      val fakeUpdateRequestUuid = UUID.randomUUID()
+      val url = Uri.Empty.withPath(BasePath / vin.get / "updates" / fakeUpdateRequestUuid.toString)
+      val result = OperationResult(UUID.randomUUID().toString, 1, "some result")
+      val updateReport = UpdateReport(fakeUpdateRequestUuid, List(result))
+      val installReport = InstallReport(vehicle.vin, updateReport)
+
+      Post(url, installReport) ~> service.route ~> check {
+        status shouldBe StatusCodes.NotFound
+        responseAs[String] should include("Could not find an update request with id ")
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdateSpec.scala
@@ -1,0 +1,66 @@
+package org.genivi.sota.core.transfer
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import org.genivi.sota.core.db._
+import org.genivi.sota.core.{DatabaseSpec, FakeExternalResolver, Generators, VehicleDatabaseSpec}
+import org.genivi.sota.core.data._
+import org.genivi.sota.core.rvi.UpdateReport
+import org.genivi.sota.core.rvi.OperationResult
+import org.genivi.sota.data.VehicleGenerators
+import org.scalacheck.Gen
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.genivi.sota.db.SlickExtensions
+import org.scalatest.time.{Millis, Seconds, Span}
+// import slick.driver.MySQLDriver.api._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstalledPackagesUpdateSpec extends FunSuite
+  with ShouldMatchers
+  with BeforeAndAfterAll
+  with Inspectors
+  with ScalaFutures
+  with DatabaseSpec
+  with VehicleDatabaseSpec {
+
+  import Generators._
+  import SlickExtensions._
+
+  implicit val actorSystem = ActorSystem("InstalledPackagesUpdateSpec-ActorSystem")
+  implicit val materializer = ActorMaterializer()
+
+  implicit val ec = ExecutionContext.global
+  implicit val _db = db
+  implicit val patience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  test("forwards request to resolver client") {
+    val resolverClient = new FakeExternalResolver
+    val vin = VehicleGenerators.genVin.sample.get
+    val packageIds = Gen.listOf(PackageIdGen).sample.get
+    val f = InstalledPackagesUpdate.update(vin, packageIds, resolverClient)
+
+    whenReady(f) { _ =>
+      forAll(packageIds) { id =>
+        resolverClient.installedPackages should contain(id)
+      }
+    }
+  }
+
+  test("marks reported packages as installed") {
+    val f = for {
+      (_, vehicle, updateSpec) <- createUpdateSpec()
+      result = OperationResult("opid", 1, "some result")
+      report = UpdateReport(updateSpec.request.id, List(result))
+      _ <- InstalledPackagesUpdate.reportInstall(vehicle.vin, report)
+      updatedSpec <- db.run(InstalledPackagesUpdate.findUpdateSpecFor(vehicle.vin, updateSpec.request.id))
+      history <- db.run(InstallHistories.list(vehicle.vin))
+    } yield (updatedSpec.status, history)
+
+    whenReady(f) { case (newStatus, history) =>
+      newStatus should be(UpdateStatus.Finished)
+      history.map(_.success) should contain(true)
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageDownloadProcessSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageDownloadProcessSpec.scala
@@ -1,0 +1,25 @@
+package org.genivi.sota.core.transfer
+
+import org.genivi.sota.core.DatabaseSpec
+import org.genivi.sota.data.VehicleGenerators
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+class PackageDownloadProcessSpec extends FunSuite
+  with ShouldMatchers
+  with DatabaseSpec
+  with ScalaFutures {
+
+  implicit val ec = scala.concurrent.ExecutionContext.global
+
+  val packageDownloadProcess = new PackageDownloadProcess(db)
+
+  test("builds a response with an empty list if there are no pending updates for a vehile") {
+    val vin = VehicleGenerators.genVin.sample.get
+    val pendingIdsResponse = packageDownloadProcess.buildClientPendingIdsResponse(vin)
+
+    whenReady(pendingIdsResponse) { uuids =>
+      uuids shouldBe empty
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -108,7 +108,7 @@ object SotaClient {
                 (implicit system: ActorSystem, mat: ActorMaterializer) : Future[Route] = {
     import system.dispatcher
 
-    val rviUri = Uri("http://127.0.0.1:8901")
+    val rviUri = Uri(system.settings.config.getString( "rvi.endpoint" ))
     implicit val clientTransport = HttpTransport( rviUri ).requestTransport
     val rviClient = new JsonRpcRviClient( clientTransport, system.dispatcher )
 

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -178,15 +178,17 @@ object Dependencies {
 
   val AkkaHttpVersion = "1.0"
 
+  val AkkaStreamVersion = AkkaHttpVersion
+
   val AkkaVersion = "2.4.0"
 
   val CirceVersion = "0.2.0"
-
 
   lazy val Akka = Seq(
     "com.typesafe.akka" % "akka-http-core-experimental_2.11" % AkkaHttpVersion,
     "com.typesafe.akka" % "akka-http-experimental_2.11" % AkkaHttpVersion,
     "com.typesafe.akka" %% "akka-http-testkit-experimental" % AkkaHttpVersion,
+    "com.typesafe.akka" %% "akka-stream-experimental" % AkkaStreamVersion,
     "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
     "ch.qos.logback" % "logback-classic" % "1.0.13"
   )


### PR DESCRIPTION
Implement new http endpoints to allow client to update packages through
http bypassing rvi.

This depends and includes #286, and it needs `export PACKAGES_VERSION_FORMAT=".+"` to run properly, as the client is at the moment sending all kinds of `Package.Id` formats. 

There are three new endpoints:

- `PUT /vehicles/:vin/packages` with a `InstalledPackages` body

- GET on `/vehicles/:vin/updates` - Returns a list of update request
  UUIDs for packages that were not still installed by the client.

- GET `/vehicles/:vin/updates/:request_id/download` - Returns the
  package data corresponding to `request_id` in a binary
  format. `request_id` should be obtained using `/updates`. This
  endpoint supports partial content download using Http Range Requests
  [1]

[1]: https://tools.ietf.org/html/rfc7233