### PR TITLE
start vehicles api when rvi absent

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -28,6 +28,10 @@ server = {
   host = ${?HOST}
   port = 8080
   port = ${?PORT}
+  hostVehicles = "localhost"
+  hostVehicles = ${?HOST_VEHICLES_API}
+  portVehicles = 8090
+  portVehicles = ${?PORT_VEHICLES_API}
 }
 
 core {

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -12,12 +12,11 @@ import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import scala.util.{Failure, Success, Try}
-
 import org.genivi.sota.core.db._
 import org.genivi.sota.core.jsonrpc.HttpTransport
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.core.transfer._
+import scala.util.{Failure, Success, Try}
 
 
 object Boot extends App with DatabaseConfig {
@@ -83,6 +82,10 @@ object Boot extends App with DatabaseConfig {
     case _ => {
       val notifier = DefaultUpdateNotifier
       Http().bindAndHandle(routes(notifier), host, port)
+      val hostVehicles = config.getString("server.hostVehicles")
+      val portVehicles = config.getInt("server.portVehicles")
+      val routesVehicles = new VehicleService(db).route
+      Http().bindAndHandle(routesVehicles, hostVehicles, portVehicles)
       FastFuture.successful(ServerServices("","","",""))
     }
   }

--- a/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
@@ -1,0 +1,40 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.{HttpResponse}
+import akka.http.scaladsl.server.{Directives, ExceptionHandler}
+import akka.stream.ActorMaterializer
+import slick.driver.MySQLDriver.api.Database
+
+
+class VehicleService(db : Database)
+                    (implicit system: ActorSystem, mat: ActorMaterializer,
+                     connectivity: Connectivity) extends Directives {
+  implicit val log = Logging(system, "vehicleservice")
+
+  import io.circe.Json
+  import Json.{obj, string}
+
+  val exceptionHandler = ExceptionHandler {
+    case e: Throwable =>
+      extractUri { uri =>
+        log.error(s"Request to $uri errored: $e")
+        val entity = obj("error" -> string(e.getMessage()))
+        complete(HttpResponse(InternalServerError, entity = entity.toString()))
+      }
+  }
+  val vehicles = new VehiclesResource(db, connectivity.client)
+
+  val route = pathPrefix("api" / "v1") {
+    handleExceptions(exceptionHandler) {
+       vehicles.route
+    }
+  }
+
+}


### PR DESCRIPTION
- configurable endpoint $HOST_VEHICLES_API:$PORT_VEHICLES_API (defaults
      to localhost:8090) for routes to let vehicles directly talk to core
      services through http without rely on rvi

depends on #288 