### PR TITLE
Remove duplicate `vehicle` in routes

### DIFF
--- a/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
@@ -56,7 +56,7 @@ object PackageId {
 
     Validate.fromPredicate(
       _.matches(packageFormat),
-      _ => "Invalid version format",
+      s => s"Invalid version format ($s)",
       ValidVersion()
     )
   }

--- a/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
@@ -55,9 +55,10 @@ class VehicleService(db : Database, resolverClient: ExternalResolverClient)
     } flatMap (_ => pass)
   }
 
-  val route = pathPrefix("api" / "v1" / "vehicles") {
+  val route = pathPrefix("api" / "v1") {
     handleExceptions(exceptionHandler) {
       vehicles.route ~
+      pathPrefix("vehicles") {
         WebService.extractVin { vin =>
           path("status") {
             val io = for {
@@ -92,9 +93,10 @@ class VehicleService(db : Database, resolverClient: ExternalResolverClient)
                       .buildReportInstallResponse(report.vin, report.update_report)
 
                   complete(responseF)
-                }
               }
+            }
           }
+        }
         }
     }
   }


### PR DESCRIPTION
Tested the current ota client master (978b793) running with this version
of ota server.

To run the client we need to run the server with the following options:

    export CORE_INTERACTION_PROTOCOL="none"
    export PACKAGES_VERSION_FORMAT=".+"

In addition, the resolver needs to be aware of the packages the client
will push. Since the current of the client will push everything reported
by `dpkg-query -W`, you'll need to run something like the following
lines to be able to download something:

    dpkg-query -f '${Package} ${Version}\n' -W |
    sort |
    uniq  |
    ruby -ne "name, version = \$_.split ; puts \"INSERT INTO Package (name, version, description, vendor) VALUES ('#{name}','#{version}', 'ats package', 'ats') ; \"" |
    mysql -u sota -p<password> --database sota_resolver -h 127.0.0.1
        
This will insert everything reported by dpkg into your db.