### PR TITLE
Fix compilation warning

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
@@ -344,7 +344,7 @@ class PackageTransferActor(updateId: UUID,
   def transferring( lastSentChunk: Int, attempt: Int ) : Receive = {
     case ChunksReceived(_, _, indexes) =>
       log.debug(s"${pckg.id.show}. Chunk received by client: $indexes" )
-      val mayBeNext = indexes.sorted.sliding(2, 1).find {
+      val nextIndex = indexes.sorted.sliding(2, 1).find {
         case first :: second :: Nil => second - first > 1
         case first :: Nil => true
         case _ => false
@@ -352,8 +352,8 @@ class PackageTransferActor(updateId: UUID,
         case first :: _ :: Nil => first + 1
         case 1 :: Nil => 2
         case Nil => 1
-      }
-      val nextIndex = mayBeNext.getOrElse(indexes.max + 1)
+        case _ => indexes.max + 1
+      }.get
       log.debug(s"Next chunk index: $nextIndex")
       if( nextIndex > lastIndex ) finish()
       else {


### PR DESCRIPTION
The warning was:
```
core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala:351: match may not be exhaustive.
[warn] It would fail on the following inputs: List((x: Int forSome x not in 1)), List((x: Int forSome x not in 1), _, _), List(1, _, _)
[warn]       }.map {
[warn]             ^
```