### PR TITLE
namespaces

### DIFF
--- a/common-data/src/main/scala/org/genivi/sota/data/Namespace.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/Namespace.scala
@@ -1,0 +1,15 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+
+package org.genivi.sota.data
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.Uri
+
+
+object Namespace {
+  // TODO schema for namespace; URI seems reasonable enough
+  type Namespace = Refined[String, Uri]
+}

--- a/common-data/src/main/scala/org/genivi/sota/data/Vehicle.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/Vehicle.scala
@@ -4,6 +4,7 @@
  */
 package org.genivi.sota.data
 
+import org.genivi.sota.data.Namespace._
 import eu.timepit.refined.api.{Refined, Validate}
 import org.joda.time.DateTime
 
@@ -11,16 +12,18 @@ import org.joda.time.DateTime
  * The notion of vehicle has a identification number (VIN), this is
  * shared between the core and resolver.
  */
-case class Vehicle(vin: Vehicle.Vin, lastSeen: Option[DateTime] = None) {
+case class Vehicle(namespace: Namespace, vin: Vehicle.Vin, lastSeen: Option[DateTime] = None) {
   override def toString(): String = s"Vehicle(${vin.get}, $lastSeen)"
 }
 
 object Vehicle {
-  def tupled: ((Vin, Option[DateTime])) => Vehicle = (Vehicle.apply _).tupled
+  def tupled: ((Namespace, Vin, Option[DateTime])) => Vehicle = { case (ns, vin, lastSeen) =>
+    Vehicle(ns, vin, lastSeen)
+  }
 
-  def fromVin: (Vin => Vehicle) = (Vehicle.apply _).curried(_)(None)
+  def fromVin: (((Namespace, Vin)) => Vehicle) = { case (ns, vin) => Vehicle(ns, vin, None) }
 
-  def toVin: Vehicle => Option[Vin] = Vehicle.unapply(_).map(_._1)
+  def toVin: Vehicle => Option[(Namespace, Vin)] = { v => Some((v.namespace, v.vin)) }
 
   case class ValidVin()
 

--- a/common-test/src/main/scala/org/genivi/sota/data/Namespaces.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/Namespaces.scala
@@ -1,0 +1,30 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.data
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.refineMV
+import org.genivi.sota.data.Namespace._
+import org.scalacheck.Gen
+
+
+trait Namespaces {
+
+  /**
+    * For property based testing purposes, we need to explain how to
+    * randomly generate namespaces.
+    *
+    * @see [[https://www.scalacheck.org/]]
+    */
+  val NamespaceGen: Gen[Namespace] = {
+    // TODO: for now, just use simple identifiers
+    Gen.identifier.map(Refined.unsafeApply)
+  }
+
+
+  val defaultNs: Namespace = refineMV("default")
+}
+
+object Namespaces extends Namespaces

--- a/common-test/src/main/scala/org/genivi/sota/data/VehicleGenerators.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/VehicleGenerators.scala
@@ -17,15 +17,16 @@ object VehicleGenerators extends VinGenerators {
         veh1.vin.get compare veh2.vin.get
     }
 
-  val genVehicle: Gen[Vehicle] =
-    genVin.map(Vehicle(_))
+  val genVehicle: Gen[Vehicle] = for {
+    vin <- genVin
+  } yield Vehicle(Namespaces.defaultNs, vin)
 
   implicit lazy val arbVehicle: Arbitrary[Vehicle] =
     Arbitrary(genVehicle)
 
-  val genInvalidVehicle: Gen[Vehicle] =
-    genInvalidVin.map(Vehicle(_))
-
-
+  val genInvalidVehicle: Gen[Vehicle] = for {
+    // TODO: for now, just generate an invalid VIN with a valid namespace
+    vin <- genInvalidVin
+  } yield Vehicle(Namespaces.defaultNs, vin)
 
 }

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -33,6 +33,8 @@ server = {
 core {
   interactionProtocol = "rvi" # or "none"
   interactionProtocol = ${?CORE_INTERACTION_PROTOCOL}
+  defaultNs = "default"
+  defaultNs = ${?DEFAULT_NAMESPACE}
 }
 
 resolver = {

--- a/core/src/main/resources/db/migration/V4__namespaces.sql
+++ b/core/src/main/resources/db/migration/V4__namespaces.sql
@@ -1,0 +1,58 @@
+-- First, clear all foreign key constraints and update primary keys.
+
+ALTER TABLE UpdateRequest
+DROP FOREIGN KEY fk_update_request_package_id,
+DROP KEY fk_update_request_package_id;
+
+ALTER TABLE UpdateSpec
+DROP FOREIGN KEY fk_update_specs_vehicle,
+DROP KEY fk_update_specs_vehicle;
+
+ALTER TABLE RequiredPackage
+DROP FOREIGN KEY fk_downloads_update_specs,
+DROP FOREIGN KEY fk_downloads_package,
+DROP KEY fk_downloads_package;
+
+ALTER TABLE InstallHistory
+DROP FOREIGN KEY install_history_vin_fk,
+DROP KEY install_history_vin_fk,
+DROP FOREIGN KEY install_history_package_id_fk,
+DROP KEY install_history_package_id_fk;
+
+-- Then, update primary keys.
+
+ALTER TABLE Vehicle
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, vin);
+
+ALTER TABLE Package
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, name, version);
+
+ALTER TABLE RequiredPackage
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, update_request_id, vin, package_name, package_version);
+
+ALTER TABLE InstallHistory
+ADD namespace CHAR(200) NOT NULL;
+
+-- At last, re-wire all foreign key constraints
+
+ALTER TABLE UpdateRequest
+ADD namespace CHAR(200) NOT NULL,
+ADD FOREIGN KEY fk_update_request_package_id (namespace, package_name, package_version) REFERENCES Package(namespace, name, version);
+
+ALTER TABLE UpdateSpec
+ADD namespace CHAR(200) NOT NULL,
+ADD FOREIGN KEY fk_update_specs_vehicle (namespace, vin) REFERENCES Vehicle(namespace, vin);
+
+ALTER TABLE RequiredPackage
+ADD FOREIGN KEY fk_downloads_update_specs (update_request_id, vin) REFERENCES UpdateSpec(update_request_id, vin),
+ADD FOREIGN KEY fk_downloads_package (namespace, package_name, package_version) REFERENCES Package(namespace, name, version);
+
+ALTER TABLE InstallHistory
+ADD FOREIGN KEY install_history_vin_fk (namespace, vin) REFERENCES Vehicle(namespace, vin),
+ADD FOREIGN KEY install_history_package_id_fk (namespace, packageName, packageVersion) REFERENCES Package(namespace, name, version);

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.{Directive1, Directives}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
@@ -17,7 +17,7 @@ import org.genivi.sota.core.jsonrpc.HttpTransport
 import org.genivi.sota.core.resolver.{Connectivity, DefaultConnectivity, DefaultExternalResolverClient}
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.core.transfer._
-
+import org.genivi.sota.data.Namespace._
 import scala.util.{Failure, Success, Try}
 
 

--- a/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
@@ -4,23 +4,25 @@
  */
 package org.genivi.sota.core
 
-import akka.event.LoggingAdapter
+import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.util.FastFuture
 import cats.Show
+import eu.timepit.refined._
+import eu.timepit.refined.string._
 import org.genivi.sota.core.data._
 import org.genivi.sota.core.db._
 import org.genivi.sota.core.resolver.Connectivity
 import org.genivi.sota.core.rvi.ServerServices
 import org.genivi.sota.core.transfer.UpdateNotifier
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
-
+import scala.collection.immutable.ListSet
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 import slick.dbio.DBIO
 import slick.driver.MySQLDriver.api.Database
 
-import scala.collection.immutable.ListSet
-import scala.concurrent.{ExecutionContext, Future}
 
 case class PackagesNotFound(packageIds: (PackageId)*)
                            (implicit show: Show[PackageId])
@@ -40,12 +42,15 @@ object UploadConf {
 }
 
 class UpdateService(notifier: UpdateNotifier)
-                   (implicit val log: LoggingAdapter, val connectivity: Connectivity) {
+                   (implicit val system: ActorSystem, val connectivity: Connectivity) {
+
   import UpdateService._
+
+  implicit private val log = Logging(system, "updateservice")
 
   def checkVins( dependencies: VinsToPackages ) : Future[Boolean] = FastFuture.successful( true )
 
-  def mapIdsToPackages(vinsToDeps: VinsToPackages )
+  def mapIdsToPackages(ns: Namespace, vinsToDeps: VinsToPackages )
                       (implicit db: Database, ec: ExecutionContext): Future[Map[PackageId, Package]] = {
     def mapPackagesToIds( packages: Seq[Package] ) : Map[PackageId, Package] = packages.map( x => x.id -> x).toMap
 
@@ -59,7 +64,7 @@ class UpdateService(notifier: UpdateNotifier)
     val requirements : Set[PackageId]  =
       vinsToDeps.foldLeft(Set.empty[PackageId])((acc, vinDeps) => acc.union(vinDeps._2) )
     for {
-      foundPackages <- db.run( Packages.byIds( requirements ) )
+      foundPackages <- db.run(Packages.byIds(ns, requirements))
       mapping       <- if( requirements.size == foundPackages.size ) {
                          FastFuture.successful( mapPackagesToIds( foundPackages ) )
                        } else {
@@ -69,9 +74,9 @@ class UpdateService(notifier: UpdateNotifier)
 
   }
 
-  def loadPackage( id : PackageId)
+  def loadPackage(ns: Namespace, id : PackageId)
                  (implicit db: Database, ec: ExecutionContext): Future[Package] = {
-    db.run(Packages.byId(id)).flatMap { x =>
+    db.run(Packages.byId(ns, id)).flatMap { x =>
       x.fold[Future[Package]](FastFuture.failed( PackagesNotFound(id)) )(FastFuture.successful)
     }
   }
@@ -81,7 +86,7 @@ class UpdateService(notifier: UpdateNotifier)
     vinsToPackageIds.map {
       case (vin, requiredPackageIds) =>
         val packages : Set[Package] = requiredPackageIds.map( idsToPackages.get ).map( _.get )
-        UpdateSpec( request, vin, UpdateStatus.Pending, packages)
+        UpdateSpec(request.namespace, request, vin, UpdateStatus.Pending, packages)
     }.toSet
   }
 
@@ -95,24 +100,24 @@ class UpdateService(notifier: UpdateNotifier)
   def queueUpdate(request: UpdateRequest, resolver : DependencyResolver )
                  (implicit db: Database, ec: ExecutionContext): Future[Set[UpdateSpec]] = {
     for {
-      pckg           <- loadPackage(request.packageId)
+      pckg           <- loadPackage(request.namespace, request.packageId)
       vinsToDeps     <- resolver(pckg)
-      packages       <- mapIdsToPackages(vinsToDeps)
+      packages       <- mapIdsToPackages(request.namespace, vinsToDeps)
       updateSpecs    = mkUploadSpecs(request, vinsToDeps, packages)
       _              <- persistRequest(request, updateSpecs)
       _              <- Future.successful(notifier.notify(updateSpecs.toSeq))
     } yield updateSpecs
   }
 
-  def queueVehicleUpdate(vin: Vehicle.Vin, packageId: PackageId)
+  def queueVehicleUpdate(ns: Namespace, vin: Vehicle.Vin, packageId: PackageId)
                         (implicit db: Database, ec: ExecutionContext): Future[UpdateRequest] = {
-    val newUpdateRequest = UpdateRequest.default(packageId)
+    val newUpdateRequest = UpdateRequest.default(ns, packageId)
 
     for {
-      p <- loadPackage(packageId)
+      p <- loadPackage(ns, packageId)
       updateRequest = newUpdateRequest.copy(signature = p.signature.getOrElse(newUpdateRequest.signature),
         description = p.description)
-      spec = UpdateSpec(updateRequest, vin, UpdateStatus.Pending, Set.empty)
+      spec = UpdateSpec(ns, updateRequest, vin, UpdateStatus.Pending, Set.empty)
       dbSpec <- persistRequest(updateRequest, ListSet(spec))
     } yield updateRequest
   }
@@ -124,5 +129,4 @@ class UpdateService(notifier: UpdateNotifier)
 object UpdateService {
   type VinsToPackages = Map[Vehicle.Vin, Set[PackageId]]
   type DependencyResolver = Package => Future[VinsToPackages]
-
 }

--- a/core/src/main/scala/org/genivi/sota/core/VehiclesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/VehiclesResource.scala
@@ -4,38 +4,39 @@
  */
 package org.genivi.sota.core
 
-import org.genivi.sota.core.resolver.ConnectivityClient
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives
-import Directives._
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.{Directive1, Directives}
 import akka.stream.ActorMaterializer
 import eu.timepit.refined._
 import eu.timepit.refined.string._
 import io.circe.generic.auto._
-import org.genivi.sota.marshalling.CirceMarshallingSupport
-import akka.http.scaladsl.marshalling.Marshaller._
+import io.circe.syntax._
+import org.genivi.sota.core.common.NamespaceDirective._
 import org.genivi.sota.core.data._
 import org.genivi.sota.core.db.{InstallHistories, UpdateSpecs, Vehicles}
+import org.genivi.sota.core.resolver.{ConnectivityClient, ExternalResolverClient}
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.Vehicle
-import org.genivi.sota.rest.Validation._
+import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.rest.ErrorRepresentation
+import org.genivi.sota.rest.Validation._
 import org.joda.time.DateTime
+import scala.concurrent.{ExecutionContext, Future}
+import scala.languageFeature.implicitConversions
+import scala.languageFeature.postfixOps
 import slick.driver.MySQLDriver.api.Database
 
-import scala.concurrent.{ExecutionContext, Future}
-import io.circe.syntax._
-import org.genivi.sota.core.resolver.ExternalResolverClient
-import scala.languageFeature.postfixOps
-import scala.languageFeature.implicitConversions
 
 class VehiclesResource(db: Database, client: ConnectivityClient, resolverClient: ExternalResolverClient)
                       (implicit system: ActorSystem, mat: ActorMaterializer) {
 
-  import system.dispatcher
   import CirceMarshallingSupport._
+  import Directives._
   import WebService._
+  import system.dispatcher
 
   implicit val _db = db
 
@@ -43,17 +44,17 @@ class VehiclesResource(db: Database, client: ConnectivityClient, resolverClient:
 
   def exists(vehicle: Vehicle)
     (implicit ec: ExecutionContext): Future[Vehicle] =
-    db.run(Vehicles.exists(vehicle.vin))
+    db.run(Vehicles.exists(vehicle))
       .flatMap(_
         .fold[Future[Vehicle]]
           (Future.failed(MissingVehicle))(Future.successful))
 
-  def deleteVin (vehicle: Vehicle)
+  def deleteVehicle(ns: Namespace, vehicle: Vehicle)
   (implicit ec: ExecutionContext): Future[Unit] =
     for {
       _ <- exists(vehicle)
-      _ <- db.run(UpdateSpecs.deleteRequiredPackageByVin(vehicle))
-      _ <- db.run(UpdateSpecs.deleteUpdateSpecByVin(vehicle))
+      _ <- db.run(UpdateSpecs.deleteRequiredPackageByVin(ns, vehicle))
+      _ <- db.run(UpdateSpecs.deleteUpdateSpecByVin(ns, vehicle))
       _ <- db.run(Vehicles.deleteById(vehicle))
     } yield ()
 
@@ -64,75 +65,76 @@ class VehiclesResource(db: Database, client: ConnectivityClient, resolverClient:
   }
 
 
-  def fetchVehicle(vin: Vehicle.Vin)  = {
-    completeOrRecoverWith(exists(Vehicle(vin))) {
+  def fetchVehicle(ns: Namespace, vin: Vehicle.Vin)  = {
+    completeOrRecoverWith(exists(Vehicle(ns, vin))) {
       case MissingVehicle =>
         complete(StatusCodes.NotFound ->
           ErrorRepresentation(ErrorCodes.MissingVehicle, "Vehicle doesn't exist"))
     }
   }
 
-  def updateVehicle(vin: Vehicle.Vin) = {
-    complete(db.run(Vehicles.create(Vehicle(vin))).map(_ => NoContent))
+  def updateVehicle(ns: Namespace, vin: Vehicle.Vin) = {
+    complete(db.run(Vehicles.create(Vehicle(ns, vin))).map(_ => NoContent))
   }
 
-  def deleteVehicle(vin: Vehicle.Vin) = {
-    completeOrRecoverWith(deleteVin(Vehicle(vin))) {
+  def deleteVehicleR(ns: Namespace, vin: Vehicle.Vin) = {
+    completeOrRecoverWith(deleteVehicle(ns, Vehicle(ns, vin))) {
       case MissingVehicle =>
         complete(StatusCodes.NotFound ->
           ErrorRepresentation(ErrorCodes.MissingVehicle, "Vehicle doesn't exist"))
     }
   }
 
-  def queuedPackages(vin: Vehicle.Vin) = {
-    complete(db.run(UpdateSpecs.getPackagesQueuedForVin(vin)))
+  def queuedPackages(ns: Namespace, vin: Vehicle.Vin) = {
+    complete(db.run(UpdateSpecs.getPackagesQueuedForVin(ns, vin)))
   }
 
-  def history(vin: Vehicle.Vin) = {
-    complete(db.run(InstallHistories.list(vin)))
+  def history(ns: Namespace, vin: Vehicle.Vin) = {
+    complete(db.run(InstallHistories.list(ns, vin)))
   }
 
-  def sync(vin: Vehicle.Vin) = {
+  def sync(ns: Namespace, vin: Vehicle.Vin) = {
     // TODO: Config RVI destination path (or ClientServices.getpackages)
+    // TODO: pass namespace
     client.sendMessage(s"genivi.org/vin/${vin}/sota/getpackages", io.circe.Json.Empty, ttl())
     // TODO: Confirm getpackages in progress to vehicle?
     complete(NoContent)
   }
 
-  def search = {
+  def search(ns: Namespace) = {
     parameters(('status.?(false), 'regex.?)) { (includeStatus: Boolean, regex: Option[String]) =>
-      val resultIO = VehicleSearch.search(regex, includeStatus)
+      val resultIO = VehicleSearch.search(ns, regex, includeStatus)
       complete(db.run(resultIO))
     }
   }
 
-  val route = {
-    pathPrefix("vehicles") {
+  val route =
+    (pathPrefix("vehicles") & extractNamespace) { ns =>
       extractVin { vin =>
         pathEnd {
           get {
-            fetchVehicle(vin)
+            fetchVehicle(ns, vin)
           } ~
           put {
-            updateVehicle(vin)
+            updateVehicle(ns, vin)
           } ~
           delete {
-            deleteVehicle(vin)
+            deleteVehicleR(ns, vin)
           }
         } ~
         (path("queued") & get) {
-          queuedPackages(vin)
+          queuedPackages(ns, vin)
         } ~
         (path("history") & get) {
-          history(vin)
+          history(ns, vin)
         } ~
         (path("sync") & put) {
-          sync(vin)
+          sync(ns, vin)
         }
       } ~
       (pathEnd & get) {
-        search
+        search(ns)
       }
     }
-  }
+
 }

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -10,7 +10,9 @@ import akka.http.scaladsl.server.{Directive1, Directives}
 import akka.stream.ActorMaterializer
 import org.genivi.sota.core.transfer.UpdateNotifier
 import slick.driver.MySQLDriver.api.Database
+import org.genivi.sota.core.common.NamespaceDirective
 import org.genivi.sota.core.resolver.{Connectivity, ExternalResolverClient}
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.Vehicle
 import eu.timepit.refined.string.Uuid
 import eu.timepit.refined._
@@ -23,12 +25,11 @@ import akka.actor.ActorSystem
 
 object WebService {
   val extractVin : Directive1[Vehicle.Vin] = refined[Vehicle.ValidVin](Slash ~ Segment)
-
   val extractUuid = refined[Uuid](Slash ~ Segment)
 }
 
 class WebService(notifier: UpdateNotifier, resolver: ExternalResolverClient, db : Database)
-                (implicit system: ActorSystem, mat: ActorMaterializer,
+                (implicit val system: ActorSystem, val mat: ActorMaterializer,
                  connectivity: Connectivity) extends Directives {
   implicit val log = Logging(system, "webservice")
 

--- a/core/src/main/scala/org/genivi/sota/core/common/Namespaces.scala
+++ b/core/src/main/scala/org/genivi/sota/core/common/Namespaces.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.common
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.directives.BasicDirectives
+import eu.timepit.refined._
+import eu.timepit.refined.string._
+import org.genivi.sota.data.Namespace._
+
+
+trait NamespaceDirective extends BasicDirectives {
+
+  type NamespaceE = Either[String, Namespace]
+
+  def defaultNs(implicit system: ActorSystem): Option[Namespace] = {
+    val nsE: NamespaceE = refineV(system.settings.config.getString("core.defaultNs"))
+    nsE.right.toOption
+  }
+
+  import eu.timepit.refined.auto._
+
+  def extractNamespace(implicit system: ActorSystem): Directive1[Namespace] = extract { _ =>
+    defaultNs.getOrElse("")
+  }
+}
+
+object NamespaceDirective extends NamespaceDirective

--- a/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
@@ -4,6 +4,7 @@
  */
 package org.genivi.sota.core.data
 
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
 import org.joda.time.DateTime
 import java.util.UUID
@@ -33,6 +34,7 @@ case class OperationResult(
  */
 case class InstallHistory(
   id            : Option[Long],
+  namespace     : Namespace,
   vin           : Vehicle.Vin,
   updateId      : UUID,
   packageId     : PackageId,

--- a/core/src/main/scala/org/genivi/sota/core/data/Package.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/Package.scala
@@ -5,6 +5,7 @@
 package org.genivi.sota.core.data
 
 import akka.http.scaladsl.model.Uri
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
 
 /**
@@ -20,6 +21,7 @@ import org.genivi.sota.data.PackageId
  * @param signature A cryptographic signature for the package
  */
 case class Package(
+  namespace: Namespace,
   id: PackageId,
   uri: Uri,
   size: Long,

--- a/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
@@ -4,11 +4,12 @@
  */
 package org.genivi.sota.core.data
 
-
-import java.util.UUID
-import org.joda.time.{DateTime, Interval, Period}
 import io.circe._
+import java.util.UUID
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
+import org.joda.time.{DateTime, Interval, Period}
+
 
 /**
  * Domain object for an update request.
@@ -30,6 +31,7 @@ import org.genivi.sota.data.{PackageId, Vehicle}
  */
 case class UpdateRequest(
   id: UUID,
+  namespace: Namespace,
   packageId: PackageId,
   creationTime: DateTime,
   periodOfValidity: Interval,
@@ -39,14 +41,17 @@ case class UpdateRequest(
   requestConfirmation: Boolean)
 
 object UpdateRequest {
-  def default(packageId: PackageId): UpdateRequest = {
+
+  import eu.timepit.refined.auto._
+
+  def default(namespace: Namespace, packageId: PackageId): UpdateRequest = {
     val updateRequestId = UUID.randomUUID()
     val now = DateTime.now
     val defaultPeriod = Period.days(1)
     val defaultInterval = new Interval(now, now.plus(defaultPeriod))
     val defaultPriority = 10
 
-    UpdateRequest(updateRequestId, packageId,
+    UpdateRequest(updateRequestId, namespace, packageId,
       DateTime.now, defaultInterval, defaultPriority, "", Some(""),
       requestConfirmation = false)
   }
@@ -74,6 +79,7 @@ import UpdateStatus._
  * @param dependencies The packages to be installed
  */
 case class UpdateSpec(
+  namespace: Namespace,
   request: UpdateRequest,
   vin: Vehicle.Vin,
   status: UpdateStatus,

--- a/core/src/main/scala/org/genivi/sota/core/data/VehicleSearch.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/VehicleSearch.scala
@@ -10,6 +10,7 @@ import slick.driver.MySQLDriver.api._
 import org.genivi.sota.core.data.VehicleStatus.VehicleStatus
 import org.genivi.sota.core.db.{UpdateSpecs, Vehicles}
 import org.genivi.sota.core.db.Vehicles.VehicleTable
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.Vehicle
 import org.joda.time.DateTime
 import org.genivi.sota.refined.SlickRefined._
@@ -36,7 +37,7 @@ object VehicleSearch {
 
   import org.genivi.sota.db.SlickExtensions.jodaDateTimeMapping
 
-  def search(regex: Option[String], includeStatus: Boolean)
+  def search(ns: Namespace, regex: Option[String], includeStatus: Boolean)
             (implicit db: Database, ec: ExecutionContext): DBIO[Json] = {
     val findQuery = regex match {
       case Some(r) => Vehicles.searchByRegex(r)

--- a/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
@@ -5,9 +5,11 @@
 package org.genivi.sota.core.db
 
 import org.genivi.sota.core.data.InstallHistory
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
 import org.joda.time.DateTime
 import slick.driver.MySQLDriver.api._
+
 
 /**
  * Database mapping definition for the InstallHistory table.
@@ -27,18 +29,19 @@ object InstallHistories {
   // scalastyle:off
   class InstallHistoryTable(tag: Tag) extends Table[InstallHistory](tag, "InstallHistory") {
 
-    def id             = column[Long]           ("id", O.PrimaryKey, O.AutoInc)
-    def vin            = column[Vehicle.Vin]    ("vin")
-    def updateId       = column[java.util.UUID] ("update_request_id")
+    def id             = column[Long]             ("id", O.PrimaryKey, O.AutoInc)
+    def namespace      = column[Namespace]        ("namespace")
+    def vin            = column[Vehicle.Vin]      ("vin")
+    def updateId       = column[java.util.UUID]   ("update_request_id")
     def packageName    = column[PackageId.Name]   ("packageName")
     def packageVersion = column[PackageId.Version]("packageVersion")
-    def success        = column[Boolean]        ("success")
-    def completionTime = column[DateTime]       ("completionTime")
+    def success        = column[Boolean]          ("success")
+    def completionTime = column[DateTime]         ("completionTime")
 
-    def * = (id.?, vin, updateId, packageName, packageVersion, success, completionTime).shaped <>
-      (r => InstallHistory(r._1, r._2, r._3, PackageId(r._4, r._5), r._6, r._7),
+    def * = (id.?, namespace, vin, updateId, packageName, packageVersion, success, completionTime).shaped <>
+      (r => InstallHistory(r._1, r._2, r._3, r._4, PackageId(r._5, r._6), r._7, r._8),
         (h: InstallHistory) =>
-          Some((h.id, h.vin, h.updateId, h.packageId.name, h.packageId.version, h.success, h.completionTime)))
+          Some((h.id, h.namespace, h.vin, h.updateId, h.packageId.name, h.packageId.version, h.success, h.completionTime)))
   }
   // scalastyle:on
 
@@ -54,8 +57,8 @@ object InstallHistories {
    * @param vin The VIN to fetch data for
    * @return A list of the install history for that VIN
    */
-  def list(vin: Vehicle.Vin): DBIO[Seq[InstallHistory]] =
-    installHistories.filter(_.vin === vin).result
+  def list(ns: Namespace, vin: Vehicle.Vin): DBIO[Seq[InstallHistory]] =
+    installHistories.filter(i => i.namespace === ns && i.vin === vin).result
 
   /**
    * Record the outcome of a install attempt on a specific VIN. The result of
@@ -65,8 +68,9 @@ object InstallHistories {
    * @param updateId The Id of the update that was attempted to be installed
    * @param success Whether the install was successful
    */
-  def log(vin: Vehicle.Vin, updateId: java.util.UUID, packageId: PackageId, success: Boolean): DBIO[Int] = {
-    installHistories += InstallHistory(None, vin, updateId, packageId, success, DateTime.now)
+  def log(ns: Namespace, vin: Vehicle.Vin, updateId: java.util.UUID,
+          packageId: PackageId, success: Boolean): DBIO[Int] = {
+    installHistories += InstallHistory(None, ns, vin, updateId, packageId, success, DateTime.now)
   }
 
 }

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -7,6 +7,7 @@ package org.genivi.sota.core.db
 import java.util.UUID
 
 import org.genivi.sota.core.data.UpdateRequest
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
 import org.joda.time.DateTime
 import slick.driver.MySQLDriver.api._
@@ -32,6 +33,7 @@ object UpdateRequests {
    */
   class UpdateRequestTable(tag: Tag) extends Table[UpdateRequest](tag, "UpdateRequest") {
     def id = column[UUID]("update_request_id", O.PrimaryKey)
+    def namespace = column[Namespace]("namespace")
     def packageName = column[PackageId.Name]("package_name")
     def packageVersion = column[PackageId.Version]("package_version")
     def creationTime = column[DateTime]("creation_time")
@@ -55,10 +57,10 @@ object UpdateRequests {
       }
     }
 
-    def * = (id, packageName, packageVersion, creationTime, startAfter, finishBefore,
+    def * = (id, namespace, packageName, packageVersion, creationTime, startAfter, finishBefore,
              priority, signature, description.?, requestConfirmation).shaped <>
-      (x => UpdateRequest(x._1, PackageId(x._2, x._3), x._4, x._5 to x._6, x._7, x._8, x._9, x._10),
-      (x: UpdateRequest) => Some((x.id, x.packageId.name, x.packageId.version, x.creationTime,
+      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11),
+      (x: UpdateRequest) => Some((x.id, x.namespace, x.packageId.name, x.packageId.version, x.creationTime,
                                   x.periodOfValidity.start, x.periodOfValidity.end, x.priority,
                                   x.signature, x.description, x.requestConfirmation)))
 

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateSpecs.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateSpecs.scala
@@ -10,6 +10,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Uuid
 import org.genivi.sota.core.data.{Package, UpdateSpec, UpdateStatus}
 import org.genivi.sota.core.db.UpdateRequests.UpdateRequestTable
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
 import org.genivi.sota.db.SlickExtensions
 import slick.driver.MySQLDriver.api._
@@ -35,14 +36,15 @@ object UpdateSpecs {
    * @see [[http://slick.typesafe.com/]]
    */
   class UpdateSpecTable(tag: Tag)
-      extends Table[(UUID, Vehicle.Vin, UpdateStatus)](tag, "UpdateSpec") {
+      extends Table[(Namespace, UUID, Vehicle.Vin, UpdateStatus)](tag, "UpdateSpec") {
+    def namespace = column[Namespace]("namespace")
     def requestId = column[UUID]("update_request_id")
     def vin = column[Vehicle.Vin]("vin")
     def status = column[UpdateStatus]("status")
 
     def pk = primaryKey("pk_update_specs", (requestId, vin))
 
-    def * = (requestId, vin, status)
+    def * = (namespace, requestId, vin, status)
   }
 
   /**
@@ -50,15 +52,16 @@ object UpdateSpecs {
    * @see {@link http://slick.typesafe.com/}
    */
   class RequiredPackageTable(tag: Tag)
-      extends Table[(UUID, Vehicle.Vin, PackageId.Name, PackageId.Version)](tag, "RequiredPackage") {
+      extends Table[(Namespace, UUID, Vehicle.Vin, PackageId.Name, PackageId.Version)](tag, "RequiredPackage") {
+    def namespace = column[Namespace]("namespace")
     def requestId = column[UUID]("update_request_id")
     def vin = column[Vehicle.Vin]("vin")
     def packageName = column[PackageId.Name]("package_name")
     def packageVersion = column[PackageId.Version]("package_version")
 
-    def pk = primaryKey("pk_downloads", (requestId, vin, packageName, packageVersion))
+    def pk = primaryKey("pk_downloads", (namespace, requestId, vin, packageName, packageVersion))
 
-    def * = (requestId, vin, packageName, packageVersion)
+    def * = (namespace, requestId, vin, packageName, packageVersion)
   }
 
   /**
@@ -83,10 +86,11 @@ object UpdateSpecs {
    * @param updateSpec The list of packages that should be installed
    */
   def persist(updateSpec: UpdateSpec) : DBIO[Unit] = {
-    val specProjection = (updateSpec.request.id, updateSpec.vin,  updateSpec.status)
+    val specProjection = (updateSpec.namespace, updateSpec.request.id, updateSpec.vin,  updateSpec.status)
 
     def dependencyProjection(p: Package) =
-      (updateSpec.request.id, updateSpec.vin, p.id.name, p.id.version)
+      // TODO: we're taking the namespace of the update spec, not necessarily the namespace of the package!
+      (updateSpec.namespace, updateSpec.request.id, updateSpec.vin, p.id.name, p.id.version)
 
     DBIO.seq(
       updateSpecs += specProjection,
@@ -102,13 +106,15 @@ object UpdateSpecs {
   def load(vin: Vehicle.Vin, updateId: UUID)
           (implicit ec: ExecutionContext) : DBIO[Iterable[UpdateSpec]] = {
     val q = for {
-      r  <- updateRequests.filter(_.id === updateId)
-      s  <- updateSpecs.filter(_.vin === vin) if (r.id === s.requestId)
-      rp <- requiredPackages if (rp.vin === vin && rp.requestId === s.requestId)
-      p  <- Packages.packages if (p.name === rp.packageName && p.version === rp.packageVersion)
+      r  <- updateRequests if (r.id === updateId)
+      s  <- updateSpecs if (s.vin === vin && s.namespace === r.namespace && s.requestId === r.id)
+      rp <- requiredPackages if (rp.vin === vin && rp.namespace === r.namespace && rp.requestId === s.requestId)
+      p  <- Packages.packages if (p.namespace === r.namespace &&
+                                  p.name === rp.packageName &&
+                                  p.version === rp.packageVersion)
     } yield (r, s.vin, s.status, p)
     q.result.map( _.groupBy(x => (x._1, x._2, x._3) ).map {
-      case ((request, vin, status), xs) => UpdateSpec(request, vin, status, xs.map(_._4).toSet )
+      case ((request, vin, status), xs) => UpdateSpec(request.namespace, request, vin, status, xs.map(_._4).toSet)
     })
   }
 
@@ -119,7 +125,7 @@ object UpdateSpecs {
    *                  InFlight, Canceled, Failed or Finished.
    */
   def setStatus( spec: UpdateSpec, newStatus: UpdateStatus ) : DBIO[Int] = {
-    updateSpecs.filter( t => t.vin === spec.vin && t.requestId === spec.request.id)
+    updateSpecs.filter(t => t.namespace === spec.namespace && t.vin === spec.vin && t.requestId === spec.request.id)
       .map( _.status )
       .update( newStatus )
   }
@@ -129,10 +135,10 @@ object UpdateSpecs {
    * @param vin The VIN to query
    * @return A List of package names + versions that are due to be installed.
    */
-  def getPackagesQueuedForVin(vin: Vehicle.Vin)
+  def getPackagesQueuedForVin(ns: Namespace, vin: Vehicle.Vin)
                              (implicit ec: ExecutionContext) : DBIO[Iterable[PackageId]] = {
-    val specs = updateSpecs.filter(r => r.vin === vin && (r.status === UpdateStatus.InFlight ||
-      r.status === UpdateStatus.Pending))
+    val specs = updateSpecs.filter(r => r.namespace === ns && r.vin === vin &&
+      (r.status === UpdateStatus.InFlight || r.status === UpdateStatus.Pending))
     val q = for {
       s <- specs
       u <- updateRequests if s.requestId === u.id
@@ -150,12 +156,12 @@ object UpdateSpecs {
    * @param pkgVer The version of the package to search for
    * @return A list of VINs that the package will be installed on
    */
-  def getVinsQueuedForPackage(pkgName: PackageId.Name, pkgVer: PackageId.Version) :
+  def getVinsQueuedForPackage(ns: Namespace, pkgName: PackageId.Name, pkgVer: PackageId.Version) :
     DBIO[Seq[Vehicle.Vin]] = {
-    val specs = updateSpecs.filter(r => r.status === UpdateStatus.Pending)
+    val specs = updateSpecs.filter(r => r.namespace === ns && r.status === UpdateStatus.Pending)
     val q = for {
       s <- specs
-      u <- updateRequests if(s.requestId === u.id) && (u.packageName === pkgName) && (u.packageVersion === pkgVer)
+      u <- updateRequests if (s.requestId === u.id) && (u.packageName === pkgName) && (u.packageVersion === pkgVer)
     } yield s.vin
     q.result
   }
@@ -164,20 +170,22 @@ object UpdateSpecs {
    * Return the status of a specific update
    * @return The update status
    */
-  def listUpdatesById(uuid: Refined[String, Uuid]): DBIO[Seq[(UUID, Vehicle.Vin, UpdateStatus)]] =
-    updateSpecs.filter(_.requestId === UUID.fromString(uuid.get)).result
+  def listUpdatesById(uuid: Refined[String, Uuid]): DBIO[Seq[(Namespace, UUID, Vehicle.Vin, UpdateStatus)]] =
+    updateSpecs.filter(s => s.requestId === UUID.fromString(uuid.get)).result
 
   /**
    * Delete all the updates for a specific VIN
    * This is part of the process for deleting a VIN from the system
    * @param vehicle The vehicle to get the VIN to delete from
    */
-  def deleteUpdateSpecByVin(vehicle : Vehicle) : DBIO[Int] = updateSpecs.filter(_.vin === vehicle.vin).delete
+  def deleteUpdateSpecByVin(ns: Namespace, vehicle: Vehicle) : DBIO[Int] =
+    updateSpecs.filter(s => s.namespace === ns && s.vin === vehicle.vin).delete
 
   /**
    * Delete all the required packages that are needed for a VIN.
    * This is part of the process for deleting a VIN from the system
    * @param vehicle The vehicle to get the VIN to delete from
    */
-  def deleteRequiredPackageByVin(vehicle : Vehicle) : DBIO[Int] = requiredPackages.filter(_.vin === vehicle.vin).delete
+  def deleteRequiredPackageByVin(ns: Namespace, vehicle : Vehicle) : DBIO[Int] =
+    requiredPackages.filter(rp => rp.namespace === ns && rp.vin === vehicle.vin).delete
 }

--- a/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
+++ b/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
@@ -12,6 +12,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
 import org.genivi.sota.marshalling.CirceMarshallingSupport
 
@@ -19,9 +20,10 @@ import scala.concurrent.Future
 
 trait ExternalResolverClient {
 
-  def putPackage(packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit]
+  def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String],
+                 vendor: Option[String]): Future[Unit]
 
-  def resolve(packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]]
+  def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]]
 
   def setInstalledPackages( vin: Vehicle.Vin, json: io.circe.Json) : Future[Unit]
 }
@@ -86,7 +88,7 @@ class DefaultExternalResolverClient(baseUri : Uri, resolveUri: Uri, packagesUri:
    * @param packageId The name and version of the package
    * @return Which packages need to be installed on which vehicles
    */
-  override def resolve(packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = {
+  override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = {
     implicit val responseDecoder : Decoder[Map[Vehicle.Vin, Set[PackageId]]] =
       Decoder[Seq[(Vehicle.Vin, Set[PackageId])]].map(_.toMap)
 
@@ -98,7 +100,7 @@ class DefaultExternalResolverClient(baseUri : Uri, resolveUri: Uri, packagesUri:
 
     request(packageId).flatMap { response =>
       Unmarshal(response.entity).to[Map[Vehicle.Vin, Set[PackageId]]].map { parsed =>
-        parsed.map { case (k, v) => Vehicle(k) -> v }
+        parsed.map { case (k, v) => Vehicle(namespace, k) -> v }
       }
     }.recover { case _ => Map.empty[Vehicle, Set[PackageId]] }
   }
@@ -156,11 +158,14 @@ class DefaultExternalResolverClient(baseUri : Uri, resolveUri: Uri, packagesUri:
    * @param description A description of the package (optional)
    * @param vendor The vendor providing the package (optional)
    */
-  override def putPackage(packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = {
+  override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String],
+                          vendor: Option[String]): Future[Unit] = {
     import akka.http.scaladsl.client.RequestBuilding._
     import shapeless._
     import syntax.singleton._
     import io.circe.generic.auto._
+
+    // TODO: actually pass the namespace
 
     val payload =
       ('id ->> ('name ->> packageId.name.get :: 'version ->> packageId.version.get :: HNil)) ::

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{HttpResponse, Uri}
 import akka.stream.ActorMaterializer
 import io.circe.Json
 import org.genivi.sota.core.resolver.DefaultExternalResolverClient
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
 
 import scala.concurrent.Future
@@ -19,9 +20,9 @@ class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterialize
     Future.successful(())
   }
 
-  override def resolve(packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = ???
+  override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = ???
 
   override def handlePutResponse(futureResponse: Future[HttpResponse]): Future[Unit] = ???
 
-  override def putPackage(packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = ???
+  override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = ???
 }

--- a/core/src/test/scala/org/genivi/sota/core/Generators.scala
+++ b/core/src/test/scala/org/genivi/sota/core/Generators.scala
@@ -4,28 +4,24 @@
  */
 package org.genivi.sota.core
 
-import eu.timepit.refined.api.Refined
 import akka.http.scaladsl.model.Uri
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption
+import eu.timepit.refined.api.Refined
+import java.nio.file.{Files, Paths, StandardOpenOption}
 import java.security.MessageDigest
 import java.util.UUID
-
 import org.apache.commons.codec.binary.Hex
-
-import org.genivi.sota.core.data.UpdateRequest
-import org.genivi.sota.core.data.Package
-import org.genivi.sota.data.{PackageId, Vehicle, VehicleGenerators}
-
 import org.genivi.sota.core.data._
-
+import org.genivi.sota.data.Namespace._
+import org.genivi.sota.data.{Namespaces, PackageId, Vehicle, VehicleGenerators}
 import org.scalacheck.{Arbitrary, Gen}
+
 
 /**
  * Generators for property-based testing of core objects
  */
 trait Generators {
+
+  import Namespaces._
 
   val PackageVersionGen: Gen[PackageId.Version] =
     Gen.listOfN(3, Gen.choose(0, 999)).map(_.mkString(".")).map(Refined.unsafeApply)
@@ -39,19 +35,20 @@ trait Generators {
   } yield PackageId( name, version )
 
   val PackageGen: Gen[Package] = for {
-    id <- PackageIdGen
+    id      <- PackageIdGen
     size    <- Gen.choose(1000L, 999999999L)
     cs      <- Gen.nonEmptyContainerOf[List, Char](Gen.alphaChar)
     desc    <- Gen.option(Arbitrary.arbitrary[String])
     vendor  <- Gen.option(Gen.alphaStr)
-  } yield Package(id, Uri(path = Uri.Path / "tmp" / s"${id.name.get}-${id.version.get}.rpm"), size, cs.mkString, desc,
-    vendor, None)
+  } yield Package(defaultNs, id, Uri(path = Uri.Path / "tmp" / s"${id.name.get}-${id.version.get}.rpm"),
+                  size, cs.mkString, desc, vendor, None)
 
   implicit val arbitrayPackage: Arbitrary[Package] = Arbitrary( PackageGen )
 
   import com.github.nscala_time.time.Imports._
 
-  def updateRequestGen(packageIdGen : Gen[PackageId]) : Gen[UpdateRequest] = for {
+  def updateRequestGen(namespaceGen: Gen[Namespace], packageIdGen : Gen[PackageId]) : Gen[UpdateRequest] = for {
+    ns           <- namespaceGen
     packageId    <- packageIdGen
     startAfter   <- Gen.choose(10, 100).map( DateTime.now + _.days)
     finishBefore <- Gen.choose(10, 100).map(x => startAfter + x.days)
@@ -59,7 +56,7 @@ trait Generators {
     sig          <- Gen.alphaStr
     desc         <- Gen.option(Arbitrary.arbitrary[String])
     reqConfirm   <- Arbitrary.arbitrary[Boolean]
-  } yield UpdateRequest(UUID.randomUUID(), packageId, DateTime.now, startAfter to finishBefore,
+  } yield UpdateRequest(UUID.randomUUID(), ns, packageId, DateTime.now, startAfter to finishBefore,
                         prio, sig, desc, reqConfirm)
 
   def vinDepGen(packages: Seq[Package]) : Gen[(Vehicle.Vin, Set[PackageId])] = for {
@@ -105,9 +102,9 @@ trait Generators {
     packageModel <- PackageGen.map(_.copy(size = smallSize.toLong))
     packageWithUri = Generators.generatePackageData(packageModel)
     vehicle <- VehicleGenerators.genVehicle
-    updateRequest <- updateRequestGen(PackageIdGen).map(_.copy(packageId = packageWithUri.id))
+    updateRequest <- updateRequestGen(defaultNs, PackageIdGen).map(_.copy(packageId = packageWithUri.id))
   } yield {
-    val updateSpec = UpdateSpec(updateRequest, vehicle.vin,
+    val updateSpec = UpdateSpec(defaultNs, updateRequest, vehicle.vin,
       UpdateStatus.Pending, List(packageWithUri).toSet)
 
     (packageWithUri, vehicle, updateSpec)

--- a/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
@@ -48,9 +48,10 @@ class PackageResourceWordSpec extends WordSpec
   lazy val service = new PackagesResource(externalResolverClient, db)
 
   val testPackagesParams = List(
-    ("vim", "7.0.1"), ("vim", "7.1.1"), ("go", "1.4.0"), ("go", "1.5.0"), ("scala", "2.11.0"))
+    ("default", "vim", "7.0.1"), ("default", "vim", "7.1.1"),
+    ("default", "go", "1.4.0"), ("default", "go", "1.5.0"), ("default", "scala", "2.11.0"))
   val testPackages:List[DataPackage] = testPackagesParams.map { pkg =>
-    DataPackage(PackageId(Refined.unsafeApply(pkg._1), Refined.unsafeApply(pkg._2)),
+    DataPackage(Refined.unsafeApply(pkg._1), PackageId(Refined.unsafeApply(pkg._2), Refined.unsafeApply(pkg._3)),
                 Uri("www.example.com"), 123, "123", None, None, None)
   }
 

--- a/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
@@ -8,15 +8,14 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling._
 import io.circe.generic.auto._
 import java.io.File
-
-import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.resolver.{ExternalResolverClient, ExternalResolverRequestFailed}
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{PackageId, Vehicle}
+import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.rest.ErrorRepresentation
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{Matchers, PropSpec}
-
 import scala.concurrent.Future
 import slick.jdbc.JdbcBackend.Database
 
@@ -38,9 +37,9 @@ class PackageUploadSpec extends PropSpec with PropertyChecks with Matchers with 
 
   class Service(resolverResult: Future[Unit] ) {
     val resolver = new ExternalResolverClient {
-      override def putPackage(packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = resolverResult
+      override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = resolverResult
 
-      override def resolve(packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = ???
+      override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Vehicle, Set[PackageId]]] = ???
 
       override def setInstalledPackages( vin: Vehicle.Vin, json: io.circe.Json) : Future[Unit] = ???
     }

--- a/core/src/test/scala/org/genivi/sota/core/PackagesReader.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackagesReader.scala
@@ -1,9 +1,10 @@
 package org.genivi.sota.core
 
 import akka.http.scaladsl.model.Uri
-import eu.timepit.refined.refineV
+import eu.timepit.refined.{refineV, refineMV}
 import eu.timepit.refined.api.Refined
 import org.genivi.sota.core.data.Package
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
 
 
@@ -22,8 +23,9 @@ object PackagesReader {
       version     <- readVersion( src.get( "Version" ) )
       size        <- src.get("Size").map( _.toLong )
       checkSum    <- src.get("SHA1")
-    } yield Package(PackageId( Refined.unsafeApply(name), version), size = size, description = src.get( "Description" ),
-                     checkSum = checkSum, uri = Uri.Empty, vendor = src.get( "Maintainer" ), signature = Some("Signature") )
+    } yield Package(refineMV("default"), PackageId(Refined.unsafeApply(name), version),
+                    size = size, description = src.get("Description"),
+                    checkSum = checkSum, uri = Uri.Empty, vendor = src.get( "Maintainer" ), signature = Some("Signature") )
     maybePackage.get
   }
 

--- a/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
@@ -76,7 +76,7 @@ trait UpdateResourcesDatabaseSpec {
 trait VehicleDatabaseSpec {
   self: DatabaseSpec =>
 
-  def createVehicle()(implicit ec: ExecutionContext): Future[Vehicle.Vin] = {
+  def createVehicle()(implicit ec: ExecutionContext): Future[Vehicle] = {
     val vehicle = VehicleGenerators.genVehicle.sample.get
     db.run(Vehicles.create(vehicle))
   }

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
@@ -1,20 +1,20 @@
 package org.genivi.sota.core
 
 import akka.event.Logging
-import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import io.circe.Encoder
-import org.genivi.sota.core.data.UpdateRequest
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSuite, ShouldMatchers}
-import org.genivi.sota.marshalling.CirceMarshallingSupport
 import io.circe.generic.auto._
 import org.genivi.sota.core.resolver.{ConnectivityClient, DefaultConnectivity}
+import org.genivi.sota.core.data.UpdateRequest
 import org.genivi.sota.core.transfer.DefaultUpdateNotifier
+import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.joda.time.DateTime
-
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSuite, ShouldMatchers}
 import scala.concurrent.Future
+
 
 class UpdateRequestResourceSpec extends FunSuite
   with ScalatestRouteTest

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestSpec.scala
@@ -2,32 +2,38 @@ package org.genivi.sota.core
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.util.FastFuture
 import io.circe.Encoder
 import io.circe.generic.auto._
 import java.util.UUID
-
-import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.core.data.UpdateRequest
 import org.genivi.sota.core.db.UpdateRequests
+import org.genivi.sota.core.resolver.{DefaultConnectivity, DefaultExternalResolverClient}
 import org.genivi.sota.core.rvi.{RviConnectivity, ServerServices}
 import org.genivi.sota.core.transfer.DefaultUpdateNotifier
+import org.genivi.sota.data.Namespaces
+import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.scalacheck.Gen
-import org.scalatest.{Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
-
+import org.scalatest.{Matchers, PropSpec}
 import scala.concurrent.Future
 import slick.jdbc.JdbcBackend.Database
-import CirceMarshallingSupport._
-import org.genivi.sota.core.resolver.{DefaultConnectivity, DefaultExternalResolverClient}
+
 
 /**
  * Spec tests for update-request REST actions
  */
-class UpdateRequestSpec extends PropSpec with PropertyChecks with Matchers with Generators with ScalatestRouteTest {
+class UpdateRequestSpec extends PropSpec
+  with PropertyChecks
+  with Matchers
+  with Generators
+  with ScalatestRouteTest
+  with Namespaces {
+
+  import CirceMarshallingSupport._
 
   val UpdatesPath = Path / "updates"
 
@@ -58,7 +64,7 @@ class UpdateRequestSpec extends PropSpec with PropertyChecks with Matchers with 
 
   property("Update requests can be listed")  {
     new Service() {
-      forAll(Gen.listOf(updateRequestGen(PackageIdGen))) { (requests: Seq[UpdateRequest]) =>
+      forAll(Gen.listOf(updateRequestGen(defaultNs, PackageIdGen))) { (requests: Seq[UpdateRequest]) =>
         // TODO: I don't think this test is running, we just create a future and never wait for it's result
         Future.sequence(requests.map(r => db.run(UpdateRequests.persist(r)))).map { _ =>
           Get( Uri(path = UpdatesPath) ) ~> resource.route ~> check {

--- a/core/src/test/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/InstalledPackagesUpdateSpec.scala
@@ -57,7 +57,7 @@ class InstalledPackagesUpdateSpec extends FunSuite
       report = UpdateReport(updateSpec.request.id, List(result))
       _ <- InstalledPackagesUpdate.reportInstall(vehicle.vin, report)
       updatedSpec <- db.run(InstalledPackagesUpdate.findUpdateSpecFor(vehicle.vin, updateSpec.request.id))
-      history <- db.run(InstallHistories.list(vehicle.vin))
+      history <- db.run(InstallHistories.list(vehicle.namespace, vehicle.vin))
     } yield (updatedSpec.status, history)
 
     whenReady(f) { case (newStatus, history) =>

--- a/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
@@ -9,6 +9,8 @@ import org.genivi.sota.core.RequiresRvi
 import org.genivi.sota.core.data.{UpdateRequest, UpdateSpec, UpdateStatus}
 import org.genivi.sota.core.jsonrpc.HttpTransport
 import org.genivi.sota.core.rvi.{SotaServices, RviConnectivity, RviUpdateNotifier}
+import org.genivi.sota.data.Namespace._
+import org.genivi.sota.data.Namespaces
 import org.genivi.sota.data.Vehicle
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
@@ -23,21 +25,27 @@ object UpdateNotifierSpec {
 
   val packages = scala.util.Random.shuffle( PackagesReader.read().take(100) )
 
-  def updateSpecGen(vinGen : Gen[Vehicle.Vin]) : Gen[UpdateSpec] = for {
-    updateRequest <- updateRequestGen(Gen.oneOf(packages).map( _.id) )
+  def updateSpecGen(namespaceGen: Gen[Namespace], vinGen : Gen[Vehicle.Vin]) : Gen[UpdateSpec] = for {
+    ns            <- namespaceGen
+    updateRequest <- updateRequestGen(ns, Gen.oneOf(packages).map( _.id) )
     vin           <- vinGen
     m             <- Gen.choose(1, 10)
     packages      <- Gen.pick(m, packages).map( _.toSet )
-  } yield UpdateSpec( updateRequest, vin, UpdateStatus.Pending, packages )
+  } yield UpdateSpec(ns, updateRequest, vin, UpdateStatus.Pending, packages )
 
-  def updateSpecsGen( vinGen : Gen[Vehicle.Vin] ) : Gen[Seq[UpdateSpec]] =
-    Gen.containerOf[Seq, UpdateSpec](updateSpecGen(vinGen))
+  def updateSpecsGen(namespaceGen: Gen[Namespace], vinGen : Gen[Vehicle.Vin] ) : Gen[Seq[UpdateSpec]] =
+    Gen.containerOf[Seq, UpdateSpec](updateSpecGen(namespaceGen, vinGen))
 }
 
 /**
  * Property-based spec for testing update notifier
  */
-class UpdateNotifierSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfterAll {
+class UpdateNotifierSpec extends PropSpec
+  with PropertyChecks
+  with Matchers
+  with BeforeAndAfterAll
+  with Namespaces {
+
   import UpdateNotifierSpec._
 
   implicit val system = akka.actor.ActorSystem("UpdateServiseSpec")
@@ -53,7 +61,7 @@ class UpdateNotifierSpec extends PropSpec with PropertyChecks with Matchers with
 
   property("notify about available updates", RequiresRvi) {
     val serviceUri = Uri.from(scheme="http", host=getLocalHostAddr, port=8088)
-    forAll( updateSpecsGen(Gen.const(Refined.unsafeApply("V1234567890123456"))) ) { specs =>
+    forAll(updateSpecsGen(defaultNs, Gen.const(Refined.unsafeApply("V1234567890123456")))) { specs =>
       val futureRes = for {
         sotaServices    <- SotaServices.register(serviceUri.withPath(Uri.Path / "rvi"))
         notifier         = new RviUpdateNotifier(sotaServices)

--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -5,6 +5,11 @@ server {
   port = ${?PORT}
 }
 
+resolver {
+  defaultNs = "default"
+  defaultNs = ${?DEFAULT_NAMESPACE}
+}
+
 database {
   driver = "org.mariadb.jdbc.Driver"
   url = "jdbc:mariadb://localhost:3306/sota_resolver"

--- a/external-resolver/src/main/resources/db/migration/V3__namespaces.sql
+++ b/external-resolver/src/main/resources/db/migration/V3__namespaces.sql
@@ -1,0 +1,88 @@
+-- First, clear all foreign key constraints and update primary keys.
+ALTER TABLE InstalledPackage
+DROP FOREIGN KEY installed_package_vin_fk;
+
+ALTER TABLE InstalledComponent
+DROP FOREIGN KEY installed_component_vin_fk;
+
+ALTER TABLE PackageFilter
+DROP FOREIGN KEY package_fk,
+DROP FOREIGN KEY filter_fk,
+DROP KEY filter_fk;
+
+ALTER TABLE InstalledPackage
+DROP FOREIGN KEY installed_package_package_fk,
+DROP KEY installed_package_package_fk;
+
+ALTER TABLE InstalledComponent
+DROP FOREIGN KEY installed_component_partNumber_fk,
+DROP KEY installed_component_partNumber_fk;
+
+ALTER TABLE Firmware
+DROP FOREIGN KEY fk_firmware_vehicle,
+DROP KEY fk_firmware_vehicle;
+
+-- Then, update primary keys.
+
+ALTER TABLE Vehicle
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, vin);
+
+ALTER TABLE Package
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, name, version);
+
+ALTER TABLE Filter
+ADD namespace CHAR(200) NOT NULL,
+DROP KEY name_unique,
+ADD UNIQUE KEY name_unique (namespace, name),
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, name);
+
+ALTER TABLE PackageFilter
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, packageName, packageVersion, filterName);
+
+ALTER TABLE InstalledPackage
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, vin, packageName, packageVersion);
+
+ALTER TABLE InstalledComponent
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, vin, partNumber);
+
+ALTER TABLE Component
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, partnumber);
+
+ALTER TABLE Firmware
+ADD namespace CHAR(200) NOT NULL,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (namespace, module, firmware_id, vin);
+
+-- At last, re-wire all foreign key constraints
+
+ALTER TABLE InstalledPackage
+ADD FOREIGN KEY installed_package_vin_fk (namespace, vin) REFERENCES Vehicle(namespace, vin);
+
+ALTER TABLE InstalledComponent
+ADD FOREIGN KEY installed_component_vin_fk (namespace, vin) REFERENCES Vehicle(namespace, vin);
+
+ALTER TABLE PackageFilter
+ADD FOREIGN KEY package_fk (namespace, packageName, packageVersion) REFERENCES Package(namespace, name, version),
+ADD FOREIGN KEY filter_fk (namespace, filterName) REFERENCES Filter(namespace, name);
+
+ALTER TABLE InstalledPackage
+ADD FOREIGN KEY installed_package_package_fk (namespace, packageName, packageVersion) REFERENCES Package(namespace, name, version);
+
+ALTER TABLE InstalledComponent
+ADD FOREIGN KEY installed_component_partNumber_fk (namespace, partNumber) REFERENCES Component(namespace, partNumber);
+
+ALTER TABLE Firmware
+ADD FOREIGN KEY fk_firmware_vehicle (namespace, vin) REFERENCES Vehicle(namespace, vin);

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/common/Namespaces.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/common/Namespaces.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.resolver.common
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.directives.BasicDirectives
+import eu.timepit.refined._
+import eu.timepit.refined.string._
+import org.genivi.sota.data.Namespace._
+
+
+trait NamespaceDirective extends BasicDirectives {
+
+  type NamespaceE = Either[String, Namespace]
+
+  def defaultNs(implicit system: ActorSystem): Option[Namespace] = {
+    val nsE: NamespaceE = refineV(system.settings.config.getString("resolver.defaultNs"))
+    nsE.right.toOption
+  }
+
+  import eu.timepit.refined.auto._
+
+  def extractNamespace(implicit system: ActorSystem): Directive1[Namespace] = extract { _ =>
+    defaultNs.getOrElse("")
+  }
+}
+
+object NamespaceDirective extends NamespaceDirective

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/components/Component.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/components/Component.scala
@@ -5,10 +5,12 @@
 package org.genivi.sota.resolver.components
 
 import eu.timepit.refined.api.{Refined, Validate}
+import org.genivi.sota.data.Namespace._
 
 
 case class Component(
-  partNumber : Component.PartNumber,
+  namespace: Namespace,
+  partNumber: Component.PartNumber,
   description: String
 ) {
   override def toString(): String = { s"Component(${partNumber.get}, $description)" }

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
@@ -6,6 +6,7 @@ package org.genivi.sota.resolver.components
 
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.db.Operators._
 import org.genivi.sota.refined.SlickRefined._
 import org.genivi.sota.resolver.common.Errors
@@ -21,12 +22,13 @@ object ComponentRepository {
   private[components] class ComponentTable(tag: Tag)
       extends Table[Component](tag, "Component") {
 
+    def namespace   = column[Namespace]           ("namespace")
     def partNumber  = column[Component.PartNumber]("partNumber")
     def description = column[String]              ("description")
 
-    def pk = primaryKey("pk_component", partNumber)
+    def pk = primaryKey("pk_component", (namespace, partNumber))
 
-    def * = (partNumber, description) <>
+    def * = (namespace, partNumber, description) <>
       ((Component.apply _).tupled, Component.unapply)
   }
   // scalastyle:on
@@ -36,18 +38,20 @@ object ComponentRepository {
   def addComponent(comp: Component): DBIO[Int] =
     components.insertOrUpdate(comp)
 
-  def removeComponent(part: Component.PartNumber)
+  def removeComponent(namespace: Namespace, part: Component.PartNumber)
                      (implicit ec: ExecutionContext): DBIO[Int] =
     for {
-      vs <- VehicleRepository.search(None, None, None, Some(part))
+      // TODO: namespace
+      vs <- VehicleRepository.search(namespace, None, None, None, Some(part))
       r  <- if (vs.nonEmpty) DBIO.failed(Errors.ComponentIsInstalledException)
-            else components.filter(_.partNumber === part).delete
+            else components.filter(i => i.namespace === namespace && i.partNumber === part).delete
     } yield r
 
-  def exists(part: Component.PartNumber)
+  def exists(namespace: Namespace,
+             part: Component.PartNumber)
             (implicit ec: ExecutionContext): DBIO[Component] =
     components
-      .filter(_.partNumber === part)
+      .filter(i => i.namespace === namespace && i.partNumber === part)
       .result
       .headOption
       .failIfNone(Errors.MissingComponent)
@@ -55,7 +59,7 @@ object ComponentRepository {
   def list: DBIO[Seq[Component]] =
     components.result
 
-  def searchByRegex(re: Refined[String, Regex]): DBIO[Seq[Component]] =
-    components.filter(comp => regex(comp.partNumber, re.get)).result
+  def searchByRegex(namespace: Namespace, re: Refined[String, Regex]): DBIO[Seq[Component]] =
+    components.filter(i => i.namespace === namespace && regex(i.partNumber, re.get)).result
 
 }

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/Filter.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/Filter.scala
@@ -4,6 +4,7 @@
  */
 package org.genivi.sota.resolver.filters
 
+import org.genivi.sota.data.Namespace._
 import eu.timepit.refined.api.{Validate, Refined}
 import org.genivi.sota.resolver.packages.Package
 import org.genivi.sota.resolver.components.Component
@@ -12,6 +13,7 @@ import org.scalacheck._
 
 
 case class Filter(
+  namespace: Namespace,
   name: Filter.Name,
   expression: Filter.Expression
 ) {

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/firmware/Firmware.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/firmware/Firmware.scala
@@ -4,10 +4,13 @@
  */
 package org.genivi.sota.resolver.data
 
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.datatype.FirmwareCommon
 import org.joda.time.DateTime
 
+
 case class Firmware(
+  namespace: Namespace,
   module: Firmware.Module,
   firmwareId: Firmware.FirmwareId,
   lastModified: DateTime

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/packages/Package.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/packages/Package.scala
@@ -4,6 +4,7 @@
  */
 package org.genivi.sota.resolver.packages
 
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
 import org.genivi.sota.resolver.filters.Filter
 
@@ -12,6 +13,7 @@ import org.genivi.sota.resolver.filters.Filter
  * Packages have an id, a String description and a String vendor
  */
 case class Package(
+  namespace  : Namespace,
   id         : PackageId,
   description: Option[String],
   vendor     : Option[String]
@@ -22,6 +24,7 @@ case class Package(
  * Filters have a package name, package version and filter name
  */
 case class PackageFilter(
+  namespace     : Namespace,
   packageName   : PackageId.Name,
   packageVersion: PackageId.Version,
   filterName    : Filter.Name

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
@@ -4,12 +4,15 @@
  */
 package org.genivi.sota.resolver.resolve
 
-import akka.http.scaladsl.server.{Route, Directives}
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.{Route, Directive1, Directives}
 import akka.stream.ActorMaterializer
 import io.circe.generic.auto._
 import org.genivi.sota.data.PackageId
+import org.genivi.sota.data.Namespace._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.common.Errors
+import org.genivi.sota.resolver.common.NamespaceDirective._
 import org.genivi.sota.resolver.common.RefinementDirectives.refinedPackageId
 import org.genivi.sota.resolver.vehicles.VehicleRepository
 import scala.concurrent.ExecutionContext
@@ -19,10 +22,13 @@ import Directives._
 /**
  * API routes for package resolution.
  */
-class ResolveDirectives(implicit db: Database, mat: ActorMaterializer, ec: ExecutionContext) {
+class ResolveDirectives(implicit system: ActorSystem,
+                        db: Database,
+                        mat: ActorMaterializer,
+                        ec: ExecutionContext) {
 
-  def resolvePackage(id: PackageId) =
-    completeOrRecoverWith(db.run(VehicleRepository.resolve(id))) {
+  def resolvePackage(ns: Namespace, id: PackageId) =
+    completeOrRecoverWith(db.run(VehicleRepository.resolve(ns, id))) {
       Errors.onMissingPackage
     }
 
@@ -32,8 +38,8 @@ class ResolveDirectives(implicit db: Database, mat: ActorMaterializer, ec: Execu
    * @throws 			Errors.MissingPackageException if the package doesn't exist
    */
   def route: Route =
-    (get & pathPrefix("resolve") & refinedPackageId) { id =>
-      resolvePackage(id)
+    (get & pathPrefix("resolve") & extractNamespace & refinedPackageId) { (ns, id) =>
+      resolvePackage(ns, id)
     }
 
 }

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentGenerators.scala
@@ -1,10 +1,11 @@
 package org.genivi.sota.resolver.test
 
 import eu.timepit.refined.refineV
+import org.genivi.sota.data.Namespaces
 import org.genivi.sota.resolver.components.Component
 import org.scalacheck.{Arbitrary, Gen}
 
-trait ComponentGenerators {
+trait ComponentGenerators extends Namespaces {
 
   // We don't want name clashes so keep the names long.
   val genLongIdent: Gen[String] = (for {
@@ -23,7 +24,7 @@ trait ComponentGenerators {
   val genComponent: Gen[Component] = for {
     partNumber  <- genPartNumber
     desc        <- Gen.identifier
-  } yield Component(partNumber, desc)
+  } yield Component(defaultNs, partNumber, desc)
 
   implicit val arbComponent: Arbitrary[Component] =
     Arbitrary(genComponent)

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentResourceSpec.scala
@@ -5,9 +5,10 @@
 package org.genivi.sota.resolver.test
 
 import akka.http.scaladsl.model.StatusCodes
-import eu.timepit.refined.refineMV
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.refineMV
 import io.circe.generic.auto._
+import org.genivi.sota.data.Namespaces
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.components.Component
 import org.genivi.sota.rest.{ErrorCodes, ErrorRepresentation}
@@ -15,7 +16,7 @@ import org.genivi.sota.rest.{ErrorCodes, ErrorRepresentation}
 /**
  * Specs for Component REST actions
  */
-class ComponentResourceWordSpec extends ResourceWordSpec {
+class ComponentResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   val components = "components"
 
@@ -50,10 +51,10 @@ class ComponentResourceWordSpec extends ResourceWordSpec {
 
       Get(Resource.uri(components)) ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[Component]] shouldBe List(Component(bobby0, "nice"),
-                                                 Component(bobby1, "nice"),
-                                                 Component(jobby0, "nice"),
-                                                 Component(jobby1, "nice"))
+        responseAs[Seq[Component]] shouldBe List(Component(defaultNs, bobby0, "nice"),
+                                                 Component(defaultNs, bobby1, "nice"),
+                                                 Component(defaultNs, jobby0, "nice"),
+                                                 Component(defaultNs, jobby1, "nice"))
       }
     }
 
@@ -61,13 +62,13 @@ class ComponentResourceWordSpec extends ResourceWordSpec {
 
       Get(Resource.uri(components) + "?regex=^j.*$") ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[Component]] shouldBe List(Component(jobby0, "nice"),
-                                                 Component(jobby1, "nice"))
+        responseAs[Seq[Component]] shouldBe List(Component(defaultNs, jobby0, "nice"),
+                                                 Component(defaultNs, jobby1, "nice"))
       }
       Get(Resource.uri(components) + "?regex=^.*0$") ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[Component]] shouldBe List(Component(bobby0, "nice"),
-                                                 Component(jobby0, "nice"))
+        responseAs[Seq[Component]] shouldBe List(Component(defaultNs, bobby0, "nice"),
+                                                 Component(defaultNs, jobby0, "nice"))
       }
     }
 
@@ -84,11 +85,10 @@ class ComponentResourceWordSpec extends ResourceWordSpec {
       }
       Get(Resource.uri(components)) ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[Component]] shouldBe List(Component(bobby0, "nice"),
-                                                 Component(bobby1, "nice"),
-                                                 Component(jobby0, "nice"))
+        responseAs[Seq[Component]] shouldBe List(Component(defaultNs, bobby0, "nice"),
+                                                 Component(defaultNs, bobby1, "nice"),
+                                                 Component(defaultNs, jobby0, "nice"))
       }
     }
-
   }
 }

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterGenerators.scala
@@ -1,14 +1,16 @@
 package org.genivi.sota.resolver.test
 
 import eu.timepit.refined.api.Refined
-import org.genivi.sota.data.SemanticVin
+import org.genivi.sota.data.{Namespaces, SemanticVin}
 import org.genivi.sota.resolver.components.Component
 import org.genivi.sota.resolver.filters._
 import org.genivi.sota.resolver.filters.FilterAST._
 import org.genivi.sota.resolver.packages.Package
 import org.scalacheck.{Arbitrary, Gen}
 
-trait FilterGenerators  {
+trait FilterGenerators {
+
+  import Namespaces._
 
   def genFilterHelper(i: Int): Gen[FilterAST] = {
 
@@ -64,7 +66,7 @@ trait FilterGenerators  {
     for {
       name <- genFilterName
       expr <- genFilterAST
-    } yield Filter(Refined.unsafeApply(name), Refined.unsafeApply(ppFilter(expr)))
+    } yield Filter(defaultNs, Refined.unsafeApply(name), Refined.unsafeApply(ppFilter(expr)))
 
   implicit val arbFilter: Arbitrary[Filter] =
     Arbitrary(genFilterViaAST)
@@ -110,7 +112,7 @@ trait FilterGenerators  {
         (100, helper(depth)),
         (1,   genFilterAST)
       )
-    } yield Filter(Refined.unsafeApply(name), Refined.unsafeApply(ppFilter(expr)))
+    } yield Filter(defaultNs, Refined.unsafeApply(name), Refined.unsafeApply(ppFilter(expr)))
 
   }
 

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterParserSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterParserSpec.scala
@@ -5,7 +5,7 @@
 package org.genivi.sota.resolver.test
 
 import eu.timepit.refined.api.Refined
-import org.genivi.sota.data.{PackageId, Vehicle}
+import org.genivi.sota.data.{Namespaces, PackageId, Vehicle}
 import org.scalacheck._
 import org.scalatest.FlatSpec
 import org.genivi.sota.resolver.filters._
@@ -82,16 +82,16 @@ class FilterParserSpec extends FlatSpec {
 /**
  * Specs for filter queries
  */
-class FilterQuerySpec extends ResourceWordSpec {
+class FilterQuerySpec extends ResourceWordSpec with Namespaces {
 
   import org.genivi.sota.resolver.packages.Package
   import org.genivi.sota.resolver.components.Component
 
-  val vin1 = Vehicle(Refined.unsafeApply("APABEPA1234567890"))
-  val vin2 = Vehicle(Refined.unsafeApply("APACEPA1234567890"))
-  val vin3 = Vehicle(Refined.unsafeApply("APADEPA1234567890"))
-  val vin4 = Vehicle(Refined.unsafeApply("BEPAEPA1234567890"))
-  val vin5 = Vehicle(Refined.unsafeApply("DEPAEPA1234567890"))
+  val vin1 = Vehicle(defaultNs, Refined.unsafeApply("APABEPA1234567890"))
+  val vin2 = Vehicle(defaultNs, Refined.unsafeApply("APACEPA1234567890"))
+  val vin3 = Vehicle(defaultNs, Refined.unsafeApply("APADEPA1234567890"))
+  val vin4 = Vehicle(defaultNs, Refined.unsafeApply("BEPAEPA1234567890"))
+  val vin5 = Vehicle(defaultNs, Refined.unsafeApply("DEPAEPA1234567890"))
 
   val pkg1 = PackageId(Refined.unsafeApply("pkg1"), Refined.unsafeApply("1.0.0"))
   val pkg2 = PackageId(Refined.unsafeApply("pkg2"), Refined.unsafeApply("1.0.0"))

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FiltersResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FiltersResourceSpec.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.unmarshalling._
 import eu.timepit.refined.api.Refined
 import io.circe._
 import io.circe.generic.auto._
+import org.genivi.sota.data.Namespaces
 import org.genivi.sota.rest.ErrorCodes
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.filters.Filter, Filter._
@@ -19,13 +20,13 @@ import org.genivi.sota.rest.{ErrorRepresentation, ErrorCode}
 /**
  * Spec for Filter REST actions
  */
-class FiltersResourceWordSpec extends ResourceWordSpec {
+class FiltersResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   "Filters resource" should {
 
     val filterName = "myfilter"
     val filterExpr = s"""vin_matches "SAJNX5745SC......""""
-    val filter     = Filter(Refined.unsafeApply(filterName), Refined.unsafeApply(filterExpr))
+    val filter     = Filter(defaultNs, Refined.unsafeApply(filterName), Refined.unsafeApply(filterExpr))
 
     "create a new resource on POST request" in {
       addFilterOK(filterName, filterExpr)
@@ -47,7 +48,7 @@ class FiltersResourceWordSpec extends ResourceWordSpec {
 
     val filterName2 = "myfilter2"
     val filterExpr2 = s"""vin_matches "TAJNX5745SC......""""
-    val filter2     = Filter(Refined.unsafeApply(filterName2), Refined.unsafeApply(filterExpr2))
+    val filter2     = Filter(defaultNs, Refined.unsafeApply(filterName2), Refined.unsafeApply(filterExpr2))
 
     "list available filters on a GET request" in {
       addFilterOK(filterName2, filterExpr2)

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageFilterResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageFilterResourceSpec.scala
@@ -7,7 +7,7 @@ package org.genivi.sota.resolver.test
 import akka.http.scaladsl.model.StatusCodes
 import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
-import org.genivi.sota.data.PackageId
+import org.genivi.sota.data.{Namespaces, PackageId}
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.common.Errors.Codes
 import org.genivi.sota.resolver.filters.Filter
@@ -17,7 +17,7 @@ import org.genivi.sota.rest.{ErrorRepresentation, ErrorCode}
 /**
  * Spec for Package Filter REST actions
  */
-class PackageFilterResourceWordSpec extends ResourceWordSpec {
+class PackageFilterResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   "Package filter resource" should {
 
@@ -26,7 +26,7 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
     val filterName = "filter"
     val filterExpr = s"""vin_matches "^X.*""""
     val pkgFilter  =
-      PackageFilter(Refined.unsafeApply(pkgName), Refined.unsafeApply(pkgVersion), Refined.unsafeApply(filterName))
+      PackageFilter(defaultNs, Refined.unsafeApply(pkgName), Refined.unsafeApply(pkgVersion), Refined.unsafeApply(filterName))
 
     "be able to assign exisiting filters to existing packages" in {
       addPackageOK(pkgName, pkgVersion, None, None)
@@ -65,7 +65,7 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
     "list packages associated to a filter on GET requests to /filters/:filterName/package" in {
       listPackagesForFilter(filterName) ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[List[Package]] shouldBe List(Package(PackageId(Refined.unsafeApply(pkgName), Refined.unsafeApply(pkgVersion)), None, None))
+        responseAs[List[Package]] shouldBe List(Package(defaultNs, PackageId(Refined.unsafeApply(pkgName), Refined.unsafeApply(pkgVersion)), None, None))
       }
     }
 
@@ -84,7 +84,7 @@ class PackageFilterResourceWordSpec extends ResourceWordSpec {
     "list filters associated to a package on GET requests to /packages/:pkgName/:pkgVersion/filter" in {
       listFiltersForPackage(pkgName, pkgVersion) ~> route ~> check {
         status shouldBe StatusCodes.OK
-        responseAs[Seq[Filter]] shouldBe List(Filter(Refined.unsafeApply(filterName), Refined.unsafeApply(filterExpr)))
+        responseAs[Seq[Filter]] shouldBe List(Filter(defaultNs, Refined.unsafeApply(filterName), Refined.unsafeApply(filterExpr)))
       }
     }
 

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageGenerators.scala
@@ -1,16 +1,16 @@
 package org.genivi.sota.resolver.test
 
-import org.genivi.sota.data.PackageIdGenerators
+import org.genivi.sota.data.{Namespaces, PackageIdGenerators}
 import org.genivi.sota.resolver.packages.Package
 import org.scalacheck.{Arbitrary, Gen}
 
-trait PackageGenerators extends PackageIdGenerators{
+trait PackageGenerators extends PackageIdGenerators with Namespaces {
 
   val genPackage: Gen[Package] = for {
     id      <- genPackageId
     desc    <- Gen.option(Arbitrary.arbitrary[String])
     vendor  <- Gen.option(Gen.alphaStr)
-  } yield Package(id, desc, vendor)
+  } yield Package(defaultNs, id, desc, vendor)
 
   implicit val arbPackage: Arbitrary[Package] =
     Arbitrary(genPackage)

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackagesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackagesResourceSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.ValidationRejection
 import eu.timepit.refined.api.Refined
 import io.circe.Json
 import io.circe.generic.auto._
-import org.genivi.sota.data.PackageId
+import org.genivi.sota.data.{Namespaces, PackageId}
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.common.Errors.Codes
 import org.genivi.sota.resolver.packages.Package
@@ -77,7 +77,7 @@ class PackagesResourcePropSpec extends ResourcePropSpec with PackageGenerators {
 /**
  * Spec for Packages REST action word processing
  */
-class PackagesResourceWordSpec extends ResourceWordSpec {
+class PackagesResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   "Packages resource" should {
 
@@ -85,11 +85,11 @@ class PackagesResourceWordSpec extends ResourceWordSpec {
       addPackage("name", "1.0.0", Some("嚢"), None) ~> route ~> check {
         status shouldBe StatusCodes.OK
         responseAs[Package] shouldBe
-          Package(PackageId(Refined.unsafeApply("name"), Refined.unsafeApply("1.0.0")), Some("嚢"), None)
+          Package(defaultNs, PackageId(Refined.unsafeApply("name"), Refined.unsafeApply("1.0.0")), Some("嚢"), None)
       }
     }
 
-    val pkg = Package(PackageId(Refined.unsafeApply("apa"), Refined.unsafeApply("1.0.0")), None, None)
+    val pkg = Package(defaultNs, PackageId(Refined.unsafeApply("apa"), Refined.unsafeApply("1.0.0")), None, None)
 
     "GET /packages/:pkgName/:pkgVersion should return the package or fail" in {
       addPackage(pkg.id.name.get, pkg.id.version.get, None, None) ~> route ~> check {

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ValidateResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ValidateResourceSpec.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.unmarshalling._
 import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
+import org.genivi.sota.data.Namespaces
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.filters.Filter
 import org.genivi.sota.rest.{ErrorRepresentation, ErrorCodes}
@@ -11,11 +12,11 @@ import org.genivi.sota.rest.{ErrorRepresentation, ErrorCodes}
 /**
  * Spec for Validate REST actions
  */
-class ValidateResourceSpec extends ResourceWordSpec {
+class ValidateResourceSpec extends ResourceWordSpec with Namespaces {
 
   "Validate resource" should {
 
-    val filter = Filter(Refined.unsafeApply("myfilter"), Refined.unsafeApply(s"""vin_matches "SAJNX5745SC......""""))
+    val filter = Filter(defaultNs, Refined.unsafeApply("myfilter"), Refined.unsafeApply(s"""vin_matches "SAJNX5745SC......""""))
 
     "accept valid filters" in {
       validateFilter(filter) ~> route ~> check {

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.StatusCodes
 import eu.timepit.refined.{refineMV, refineV}
 import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
-import org.genivi.sota.data.{PackageId, Vehicle}
+import org.genivi.sota.data.{Namespaces, PackageId, Vehicle}
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.resolver.common.Errors.Codes
 import org.genivi.sota.resolver.packages.{Package, PackageFilter}
@@ -83,14 +83,14 @@ class VehiclesResourcePropSpec extends ResourcePropSpec
 /**
  * Word Spec for Vehicle REST actions
  */
-class VehiclesResourceWordSpec extends ResourceWordSpec {
+class VehiclesResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   val vehicles = "vehicles"
 
   val vin     : Vehicle.Vin = refineV[Vehicle.ValidVin]("V1N00LAM0FAU2DEEP").right.get
-  val vehicle : Vehicle     = Vehicle(vin)
+  val vehicle : Vehicle     = Vehicle(defaultNs, vin)
   val vin2    : Vehicle.Vin = refineV[Vehicle.ValidVin]("XAPABEPA123456789").right.get
-  val vehicle2: Vehicle     = Vehicle(vin2)
+  val vehicle2: Vehicle     = Vehicle(defaultNs, vin2)
 
   "Vin resource" should {
 


### PR DESCRIPTION
    introduces namespaces

    - introduce $DEFAULT_NAMESPACE with value "default"
    - migration script for schema v3 (resolver) and v4 (core) for namespaces
    - changes to core and resolver data types to accomodate namespaces
    - updates to tests accordingly
    - NamespaceDirective let's you extract the current namespace by injecting
      the default namespace (or the empty namespace if not available).