### PR TITLE
collecting statistics of test.Random coverage

### DIFF
--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -37,3 +37,10 @@ test-database = {
   url = "jdbc:mariadb://localhost:3306/sota_resolver_test"
   url = ${?RESOLVER_TEST_DB_URL}
 }
+
+test {
+  random {
+    minSuccessful = 200
+    minSuccessful = ${?RESOLVER_TEST_RANDOM_MINSUCCESSFUL}
+  }
+}

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Query.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Query.scala
@@ -33,10 +33,6 @@ final case class  Resolve(id: PackageId)              extends Query
 final case object ListComponents                      extends Query
 final case class  ListComponentsFor(veh: Vehicle)     extends Query
 
-// TODO Query: vehicles having component
-// TODO Query: components for vehicle
-// TODO Query: filters for package
-
 object Query extends
     VehicleRequestsHttp with
     PackageRequestsHttp with

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Session.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Session.scala
@@ -11,7 +11,85 @@ import Store._
 import scala.concurrent.ExecutionContext
 
 
-case class Session(commands: List[Command], queries: List[Query])
+case class Session(commands: List[Command], queries: List[Query]) {
+
+  def coverageInfo: SessionCoverage =
+    SessionCoverage((commands ++ queries).map(_.getClass).toSet)
+
+}
+
+/**
+  * Endpoints (encompassing commands and queries) that are exercised.
+  */
+case class SessionCoverage(covered: Set[Class[_]]) extends AnyVal {
+
+  def merge(that: SessionCoverage): SessionCoverage =
+    SessionCoverage(covered.union(that.covered))
+
+  /**
+    * Each position corresponds to an endpoint (command or query).
+    * '1' indicates this session tests that endpoint, '0' otherwise.
+    */
+  override def toString: String = {
+    val cs = Array.ofDim[Char](SessionCoverage.testSpaceSize)
+    java.util.Arrays.fill(cs, '0')
+    for (c <- covered) {
+      val idx = SessionCoverage.testSpace.indexOf(c)
+      cs(idx) = '1'
+    }
+    new String(cs)
+  }
+
+  def percent: Float = (covered.size / SessionCoverage.testSpaceSize.toFloat) * 100
+
+  def untested: Set[String] =
+    (SessionCoverage.testSpace.toSet -- covered) map { _.getSimpleName }
+
+  def fullCoverage: Boolean = untested.isEmpty
+
+}
+
+object SessionCoverage {
+
+  def testSpaceSize: Int = testSpace.length
+
+  def emptyCoverageInfo: SessionCoverage = SessionCoverage(Set.empty)
+
+  /**
+    * Used to determine how much test coverage a Session achieves.
+    * Alphabetically sorted to detect more easily missing commands.
+    */
+  val testSpace: Array[Class[_]] = Array(
+
+    // commands
+    classOf[AddComponent],
+    classOf[AddFilter],
+    classOf[AddFilterToPackage],
+    classOf[AddPackage],
+    classOf[AddVehicle],
+    classOf[EditComponent],
+    classOf[EditFilter],
+    classOf[InstallComponent],
+    classOf[InstallPackage],
+    classOf[RemoveComponent],
+    classOf[RemoveFilter],
+    classOf[RemoveFilterForPackage],
+    classOf[UninstallComponent],
+    classOf[UninstallPackage],
+
+    // queries
+    ListVehicles.getClass,
+    classOf[ListPackagesOnVehicle],
+    classOf[ListVehiclesFor],
+    classOf[ListPackagesFor],
+    ListFilters.getClass,
+    classOf[ListFiltersFor],
+    classOf[Resolve],
+    ListComponents.getClass,
+    classOf[ListComponentsFor]
+  )
+
+}
 
 object Session {
 
@@ -40,8 +118,11 @@ object Session {
     } yield Session(cmds, qrys)
 
   implicit def shrinkSession: Shrink[Session] =
-    Shrink { case Session(cmds, qry) =>
-      for { cmds2 <- shrink(cmds) } yield Session(cmds2, qry)
+    Shrink { case Session(cmds, qrys) =>
+      for {
+        cmds2 <- shrink(cmds)
+        qrys2 <- shrink(qrys)
+      } yield Session(cmds2, qrys2)
     }
 
 }


### PR DESCRIPTION
- The stats track only "kinds of commands" but not values in particular instances.
- The aggregation does not distinguish which commands were part of which Sessions.