### PR TITLE
Upload packages to s3 instead of local file system

### DIFF
--- a/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
@@ -12,6 +12,8 @@ import com.typesafe.config.ConfigFactory
 case class PackageId(name   : PackageId.Name,
                      version: PackageId.Version) {
   override def toString(): String = s"PackageId(${name.get}, ${version.get})"
+
+  def mkString = s"${name.get}-${version.get}"
 }
 
 /**

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -35,6 +35,11 @@ core {
   interactionProtocol = ${?CORE_INTERACTION_PROTOCOL}
   defaultNs = "default"
   defaultNs = ${?DEFAULT_NAMESPACE}
+  s3 = {
+    accessKey = ${?CORE_AWS_ACCESS_KEY}
+    secretKey = ${?CORE_AWS_SECRET_KEY}
+    bucketId = ${?CORE_AWS_S3_BUCKET_ID}
+  }
 }
 
 resolver = {

--- a/core/src/main/scala/org/genivi/sota/core/DigestCalculator.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DigestCalculator.scala
@@ -10,16 +10,19 @@ import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
 import org.apache.commons.codec.binary.Hex
+import org.genivi.sota.core.DigestCalculator.DigestResult
 
 object DigestCalculator {
+  type DigestResult = String
+
   def apply(algorithm: String = "SHA-1"): DigestCalculator = new DigestCalculator(algorithm)
 }
 
 class DigestCalculator(algorithm: String) extends GraphStage[FlowShape[ByteString, String]] {
   val in = Inlet[ByteString]("Digest.in")
-  val out = Outlet[String]("Digest.out")
+  val out = Outlet[DigestResult]("Digest.out")
 
-  override def shape: FlowShape[ByteString, String] = FlowShape(in, out)
+  override def shape: FlowShape[ByteString, DigestResult] = FlowShape(in, out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = {
     new GraphStageLogic(shape) {

--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -7,28 +7,25 @@ package org.genivi.sota.core
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.common.StrictForm
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.DebuggingDirectives
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.stream._
-import akka.stream.scaladsl.FileIO
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex
 import io.circe.generic.auto._
-import java.nio.file.{Path, Paths}
 import org.genivi.sota.core.common.NamespaceDirective._
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.db.{Packages, UpdateSpecs}
 import org.genivi.sota.core.resolver.{ExternalResolverClient, ExternalResolverRequestFailed}
+import org.genivi.sota.core.storage.PackageStorage
 import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
 import org.genivi.sota.marshalling.RefinedMarshallingSupport._
 import org.genivi.sota.rest.ErrorRepresentation
 import org.genivi.sota.rest.Validation._
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
 import slick.driver.MySQLDriver.api.Database
-
 
 object PackagesResource {
   /**
@@ -48,46 +45,14 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database)
   import org.genivi.sota.marshalling.CirceMarshallingSupport._
   import PackagesResource._
 
+  implicit val _config = system.settings.config
+
   private[this] val log = Logging.getLogger(system, "org.genivi.sota.core.PackagesResource")
 
-  /**
-    * The location on disk where uploaded package are stored.
-    */
-  val storePath: Path = Paths.get(system.settings.config.getString("upload.store"))
-
-  import cats.syntax.show._
-
-  /**
-    * Handle an incomming file upload.
-    * Write the contents to disk, while calculating the SHA-1 hash of the
-    * package's contents
-    *
-    * @param packageId The name/version number of the package this is being uploaded
-    * @param fileData  A stream of the package contents
-    * @return A tuple of the URI where the package is available, the package
-    *         size and the package's checksum
-    */
-  def savePackage(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, Long, String)] = {
-    val fileName = fileData.filename.getOrElse(s"${packageId.name.get}-${packageId.version.get}")
-    val file = storePath.resolve(fileName).toFile
-    val data = fileData.entity.dataBytes
-    val uploadResult: Future[(Uri, Long, String)] = for {
-      ioResult <- data.runWith(FileIO.toFile(file))
-      digest <- data.via(DigestCalculator("SHA-1")).runFold("")(_ ++ _)
-    } yield (file.toURI().toString(), ioResult.count, digest)
-
-    uploadResult.onComplete {
-      case Success((uri, size, digest)) =>
-        log.debug(s"Package ${packageId.show} uploaded to $uri. Check sum: $digest")
-      case Failure(t) =>
-        log.error(t, s"Failed to save package ${packageId.show}")
-    }
-    uploadResult
-  }
+  val packageStorage = new PackageStorage()
 
   def searchPackage(ns: Namespace): Route = {
     parameters('regex.as[String Refined Regex].?) { (regex: Option[String Refined Regex]) =>
-      import org.genivi.sota.marshalling.CirceMarshallingSupport._
       val query = regex match {
         case Some(r) => Packages.searchByRegex(ns, r.get)
         case None => Packages.list
@@ -112,7 +77,7 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database)
         completeOrRecoverWith(
           for {
             _ <- resolver.putPackage(ns, pid, description, vendor)
-            (uri, size, digest) <- savePackage(pid, fileData)
+            (uri, size, digest) <- packageStorage.store(pid, fileData)
             _ <- db.run(Packages.create(
               Package(ns, pid, uri, size, digest, description, vendor, signature)))
           } yield StatusCodes.NoContent
@@ -132,7 +97,7 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database)
     complete(db.run(UpdateSpecs.getVinsQueuedForPackage(ns, pid.name, pid.version)))
   }
 
-  val route = {
+  val route =
     pathPrefix("packages") {
       (get & extractNamespace & pathEnd) { ns =>
         searchPackage(ns)
@@ -151,5 +116,4 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database)
         }
       }
     }
-  }
 }

--- a/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/VehicleService.scala
@@ -24,6 +24,7 @@ import org.genivi.sota.rest.Validation.refined
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import io.circe.Json
 import org.genivi.sota.core.resolver.ExternalResolverClient
+import org.genivi.sota.core.storage.{PackageStorage, S3PackageStore}
 
 
 class VehicleService(db : Database, resolverClient: ExternalResolverClient)
@@ -32,10 +33,13 @@ class VehicleService(db : Database, resolverClient: ExternalResolverClient)
   import Json.{obj, string}
   import WebService._
 
-  val packageDownloadProcess = new PackageDownloadProcess(db)
-
   implicit val ec = system.dispatcher
   implicit val _db = db
+  implicit val _config = system.settings.config
+
+  lazy val packageRetrievalOp = (new PackageStorage).retrieveResponse _
+
+  lazy val packageDownloadProcess = new PackageDownloadProcess(db, packageRetrievalOp)
 
   def logVehicleSeen(vehicle: Vehicle): Directive0 = {
     extractRequestContext flatMap { _ =>

--- a/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Paths
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.common.StrictForm
+import akka.http.scaladsl.model._
+import akka.stream._
+import akka.stream.scaladsl.{FileIO, Sink}
+import akka.util.ByteString
+import org.genivi.sota.core.DigestCalculator.DigestResult
+import org.genivi.sota.data.PackageId
+import scala.concurrent.Future
+
+
+class LocalPackageStore()(implicit val system: ActorSystem, val mat: ActorMaterializer) extends PackageStore {
+  import PackageStorage._
+  import system.dispatcher
+
+  val storePath = Paths.get(system.settings.config.getString("upload.store"))
+
+  val log = Logging.getLogger(system, this)
+
+  protected def localFileSink(packageId: PackageId, filename: String,
+                              fileData: StrictForm.FileData): Sink[ByteString, Future[(Uri, PackageSize)]] = {
+    val file = storePath.resolve(filename).toFile
+    val uri = Uri(file.toURI.toString)
+
+    FileIO
+      .toFile(file)
+      .mapMaterializedValue(_.map(result => (uri, result.count)))
+  }
+
+  override def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)] = {
+    val fileName = packageFileName(packageId, fileData.filename)
+    val sink = localFileSink(packageId, fileName, fileData)
+    val dataStream = fileData.entity.dataBytes
+    writePackage(packageId, dataStream, sink)
+  }
+
+  def retrieve(packageId: PackageId, packageUri: Uri): Future[(Uri, UniversalEntity)] = {
+    val file = new File(new URI(packageUri.toString()))
+    val size = file.length()
+    val source = FileIO.fromFile(file)
+    Future.successful {
+      (packageUri, HttpEntity(MediaTypes.`application/octet-stream`, size, source))
+    }
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
@@ -1,0 +1,106 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.event.{Logging, LoggingAdapter}
+import akka.http.scaladsl.common.StrictForm
+import akka.stream._
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
+import com.typesafe.config.Config
+import org.genivi.sota.core.DigestCalculator
+import org.genivi.sota.core.DigestCalculator.DigestResult
+import org.genivi.sota.core.storage.PackageStorage.PackageSize
+import org.genivi.sota.data.PackageId
+import org.genivi.sota.core.data.Package
+import akka.http.scaladsl.model._
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+class PackageStorage()(implicit system: ActorSystem, mat: ActorMaterializer, config: Config) {
+  def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)] = {
+    storage.store(packageId, fileData)
+  }
+
+  def retrieveResponse(packageModel: Package): Future[HttpResponse] = {
+    import system.dispatcher
+
+    if(isS3Uri(packageModel.uri)) {
+      s3Storage.retrieve(packageModel.id, packageModel.uri) map { case (uri, _) =>
+        HttpResponse(StatusCodes.Found, headers.Location(uri) :: Nil)
+      }
+    } else {
+      new LocalPackageStore().retrieve(packageModel.id, packageModel.uri) map { case (_, entity) =>
+        HttpResponse(StatusCodes.OK, entity = entity)
+      }
+    }
+  }
+
+  private def isS3Uri(uri: Uri) = {
+    uri.scheme.startsWith("https") &&
+      uri.authority.host.address().endsWith("amazonaws.com")
+  }
+
+  protected [storage] lazy val storage: PackageStore = {
+    S3PackageStore.loadCredentials(config) match {
+      case Some(c) => new S3PackageStore(c)
+      case None => new LocalPackageStore()
+    }
+  }
+
+  private lazy val s3Storage: S3PackageStore = {
+    S3PackageStore.loadCredentials(config) match {
+      case Some(c) => new S3PackageStore(c)
+      case None => throw new Exception("Could not get s3 credentials from config")
+    }
+  }
+}
+
+object PackageStorage {
+  import cats.syntax.show._
+  type PackageSize = Long
+  type PackageRetrievalOp = Package => Future[HttpResponse]
+  type PackageStorageOp = (PackageId, StrictForm.FileData) => Future[(Uri, PackageSize, DigestResult)]
+
+  private val HASH_ALGORITHM = "SHA-1"
+
+  protected [storage] def writePackage(packageId: PackageId,
+                                       fileData: Source[ByteString, NotUsed],
+                                       sink: Sink[ByteString, Future[(Uri, PackageSize)]])
+                  (implicit system: ActorSystem, mat: ActorMaterializer): Future[(Uri, PackageSize, DigestResult)] = {
+    implicit val ec = system.dispatcher
+    val log = Logging.getLogger(system, this)
+    val digestCalculator = DigestCalculator(HASH_ALGORITHM)
+
+    val writeAsync = for {
+      (uri, sizeBytes) <- fileData.runWith(sink)
+      digest <- fileData.via(digestCalculator).runFold("")(_ ++ _)
+    } yield (uri, sizeBytes, digest)
+
+    writeAsync andThen logResult(log, packageId)
+  }
+
+  protected [storage] def packageFileName(packageId: PackageId, providedFilename: Option[String]) = {
+    packageId.mkString + "-" + providedFilename.getOrElse("")
+  }
+
+  private def logResult(log: LoggingAdapter, packageId: PackageId)
+  : PartialFunction[Try[(Uri, PackageSize, DigestResult)], Unit] = {
+    case Success((uri, size, digest)) =>
+      log.debug(s"Package ${packageId.show} uploaded to $uri. Check sum: $digest")
+    case Failure(t) =>
+      log.error(t, s"Failed to save package ${packageId.show}")
+  }
+}
+
+trait PackageStore {
+  def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)]
+
+  def retrieve(packageId: PackageId, packageUri: Uri): Future[(Uri, UniversalEntity)]
+}
+

--- a/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
@@ -1,0 +1,111 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import java.io.InputStream
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.common.StrictForm.FileData
+import akka.http.scaladsl.model._
+import akka.stream._
+import akka.stream.scaladsl.StreamConverters
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model._
+import com.typesafe.config.Config
+import org.genivi.sota.core.DigestCalculator.DigestResult
+import org.genivi.sota.core.data.Package
+import org.genivi.sota.data.PackageId
+import org.joda.time.{DateTime, Period}
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class S3PackageStore(credentials: S3Credentials)
+                    (implicit val system: ActorSystem, val mat: ActorMaterializer) extends PackageStore {
+  import PackageStorage._
+  import system.dispatcher
+
+  val PUBLIC_URL_EXPIRE_TIME = Period.days(1)
+
+  val bucketId = credentials.bucketId
+
+  lazy val s3client = {
+    val client = new AmazonS3Client(credentials)
+    client.setRegion(Region.getRegion(Regions.EU_CENTRAL_1))
+    client
+  }
+
+  override def store(packageId: PackageId, fileData: FileData): Future[(Uri, PackageSize, DigestResult)] = {
+    val filename = packageFileName(packageId, fileData.filename)
+
+    val sink = StreamConverters.asInputStream()
+      .mapMaterializedValue { is => upload(is, filename, fileData) }
+
+    writePackage(packageId, fileData.entity.dataBytes, sink)
+  }
+
+  protected def signedUri(packageId: PackageId, uri: Uri): Future[Uri] = {
+    val expire = DateTime.now.plus(PUBLIC_URL_EXPIRE_TIME).toDate
+    val filename = Try(uri.path.reverse.head.toString).getOrElse("/404")
+    val f = Future { s3client.generatePresignedUrl(bucketId, filename, expire)}
+    f map (uri => Uri(uri.toURI.toString))
+  }
+
+  protected def upload(is: InputStream, fileName: String, fileData: FileData): Future[(Uri, Long)] = {
+    val metadata = new ObjectMetadata()
+    metadata.setContentLength(fileData.entity.contentLength)
+
+    val request = new PutObjectRequest(bucketId, fileName, is, metadata)
+      .withCannedAcl(CannedAccessControlList.AuthenticatedRead)
+
+    val asyncPut = for {
+      putResult <- Future { s3client.putObject(request) }
+      url <- Future { s3client.getUrl(bucketId, fileName) }
+    } yield (putResult, url)
+
+    asyncPut map { case (putResult, url)  =>
+      (Uri(url.toString), putResult.getMetadata.getContentLength)
+    }
+  }
+
+  override def retrieve(packageId: PackageId, packageUri: Uri): Future[(Uri, UniversalEntity)] = {
+    signedUri(packageId, packageUri).map((_, HttpEntity.Empty))
+  }
+}
+
+object S3PackageStore {
+  lazy val logger = LoggerFactory.getLogger(this.getClass)
+
+  protected [storage] def loadCredentials(config: Config): Option[S3Credentials] = {
+    val t = for {
+      accessKey <- Try(config.getString("core.s3.accessKey"))
+      secretKey <- Try(config.getString("core.s3.secretKey"))
+      bucketId <- Try(config.getString("core.s3.bucketId"))
+    } yield {
+      val result = List(accessKey, secretKey, bucketId)
+
+      if(result.forall(_.nonEmpty)) {
+        Option(new S3Credentials(accessKey, secretKey, bucketId))
+      } else {
+        logger.warn("Could not initialize s3 credentials with empty parameters")
+        None
+      }
+    }
+
+    t.toOption.flatten
+  }
+}
+
+
+class S3Credentials(accessKey: String, secretKey: String, val bucketId: String) extends AWSCredentials {
+  override def getAWSAccessKeyId: String = accessKey
+
+  override def getAWSSecretKey: String = secretKey
+}
+

--- a/core/src/test/scala/org/genivi/sota/core/DigestCalculatorSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DigestCalculatorSpec.scala
@@ -40,7 +40,7 @@ class DigestCalculatorSpec extends TestKit(ActorSystem("DigestCalculatorTest"))
     val tempFile = File.createTempFile("testfile", ".txt")
 
     val ioResult = Source.single(ByteString("Some text"))
-        .toMat(FileIO.toFile(tempFile))(Keep.right).run()
+      .runWith(FileIO.toFile(tempFile))
 
     whenReady(ioResult) { _ =>
       val probe = TestSink.probe[String]

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -1,6 +1,7 @@
 package org.genivi.sota.core
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.model.{HttpResponse, Uri}
 import akka.stream.ActorMaterializer
 import io.circe.Json
@@ -14,6 +15,8 @@ class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterialize
 {
   val installedPackages = scala.collection.mutable.Queue.empty[PackageId]
 
+  val logger = Logging.getLogger(system, this)
+
   override def setInstalledPackages(vin: Vehicle.Vin, json: Json): Future[Unit] = {
     val ids = json.as[List[PackageId]].getOrElse(List.empty)
     installedPackages.enqueue(ids:_*)
@@ -24,5 +27,8 @@ class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterialize
 
   override def handlePutResponse(futureResponse: Future[HttpResponse]): Future[Unit] = ???
 
-  override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = ???
+  override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = {
+    logger.info(s"Fake resolver called. namespace=$namespace, packageId=${packageId.mkString}")
+    Future.successful(())
+  }
 }

--- a/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+
+package org.genivi.sota.core
+
+import java.io.File
+import java.net.URI
+
+import org.genivi.sota.marshalling.CirceMarshallingSupport._
+import io.circe.generic.auto._
+import org.genivi.sota.core.data.{Package => DataPackage}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.stream.scaladsl.FileIO
+import akka.util.ByteString
+import io.circe.generic.auto._
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSuite, ShouldMatchers}
+
+import scala.concurrent.Future
+
+class PackagesResourceSpec extends FunSuite
+  with ScalatestRouteTest
+  with DatabaseSpec
+  with ShouldMatchers
+  with ScalaFutures
+{
+  val resolver = new FakeExternalResolver()
+
+  val subject = new PackagesResource(resolver, db)
+
+  val BasePath = Path("/packages")
+
+  val entity = HttpEntity(ByteString("Some Text"))
+
+  val multipartForm =
+    Multipart.FormData(Multipart.FormData.BodyPart.Strict(
+      "file",
+      entity,
+      Map("filename" -> "linux-lts.rpm")))
+
+  def readFile(uri: Uri): Future[ByteString] = {
+    FileIO.fromFile(new File(new URI(uri.toString())))
+      .runFold(ByteString.empty)(_ ++ _)
+  }
+
+  test("save packet to local file system") {
+    val service = new PackagesResource(resolver, db)
+    val url = Uri.Empty.withPath(BasePath / "linux-lts" / "4.5.0")
+
+    Put(url, multipartForm) ~> service.route ~> check {
+      status shouldBe StatusCodes.NoContent
+
+      Get("/packages") ~> service.route ~> check {
+        val dataPackage = responseAs[List[DataPackage]].headOption
+        dataPackage.map(_.id.name.get) should contain("linux-lts")
+
+        whenReady(readFile(dataPackage.get.uri)) { contents =>
+          contents shouldBe ByteString("Some Text")
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
@@ -17,7 +17,8 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.stream.scaladsl.FileIO
 import akka.util.ByteString
 import io.circe.generic.auto._
-
+import org.genivi.sota.core.storage.PackageStorage.PackageStorageOp
+import org.genivi.sota.core.storage.{LocalPackageStore, PackageStorage}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, ShouldMatchers}
 
@@ -31,7 +32,9 @@ class PackagesResourceSpec extends FunSuite
 {
   val resolver = new FakeExternalResolver()
 
-  val subject = new PackagesResource(resolver, db)
+  val service = new PackagesResource(resolver, db) {
+    override val packageStorageOp: PackageStorageOp = new LocalPackageStore().store _
+  }
 
   val BasePath = Path("/packages")
 
@@ -49,7 +52,6 @@ class PackagesResourceSpec extends FunSuite
   }
 
   test("save packet to local file system") {
-    val service = new PackagesResource(resolver, db)
     val url = Uri.Empty.withPath(BasePath / "linux-lts" / "4.5.0")
 
     Put(url, multipartForm) ~> service.route ~> check {

--- a/core/src/test/scala/org/genivi/sota/core/Tags.scala
+++ b/core/src/test/scala/org/genivi/sota/core/Tags.scala
@@ -3,3 +3,5 @@ package org.genivi.sota.core
 import org.scalatest.Tag
 
 object RequiresRvi extends Tag("RequiresRvi")
+
+object IntegrationTest extends Tag("IntegrationTest")

--- a/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.common.StrictForm
+import akka.http.scaladsl.model.{HttpEntity, Uri}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import akka.util.ByteString
+import org.genivi.sota.data.PackageIdGenerators
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSuiteLike, ShouldMatchers}
+
+class LocalPackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))
+  with FunSuiteLike
+  with ShouldMatchers
+  with ScalaFutures {
+
+  implicit val mat = ActorMaterializer()
+
+  val entity = HttpEntity(ByteString("""Build no Utopia, Lydia, for the time
+                                       |You fancy yet to be, nor count upon
+                                       |Tomorrow. Today fulfils itself, and does not wait.
+                                       |You are yourself your life.
+                                       |Contrive no plan, for you are not to be.
+                                       |Perhaps between the cup you drain
+                                       |And the same replenished, Fate
+                                       |Will interpose the void.""".stripMargin))
+
+  val fileData = StrictForm.FileData(Some("filename.rpm"), entity)
+
+  test("writes file to local storage") {
+    val storage = new LocalPackageStore()
+    val packageId = PackageIdGenerators.genPackageId.sample.get
+
+    val f = storage.store(packageId, fileData)
+
+    whenReady(f) { case (uri, byteSize, digest) =>
+      uri.path.toString should endWith("filename.rpm")
+      digest shouldBe "8107fd9e4318dd77110498ac70b1796fec11bf8c"
+      byteSize shouldBe 282
+    }
+  }
+
+  test("builds response from local storage") {
+    import system.dispatcher
+
+    val storage = new LocalPackageStore()
+    val packageId = PackageIdGenerators.genPackageId.sample.get
+
+    val f = for {
+      (uri, _, _) <- storage.store(packageId, fileData)
+      (_, entity) <- storage.retrieve(packageId, uri)
+      contents <- entity.dataBytes.runFold(ByteString(""))(_ ++ _)
+    } yield contents
+
+    whenReady(f) { contents =>
+      contents shouldNot be(empty)
+      contents shouldBe fileData.entity.data
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/storage/PackageStorageSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/PackageStorageSpec.scala
@@ -1,0 +1,59 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.genivi.sota.core.Generators
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSuiteLike, ShouldMatchers}
+
+import scala.collection.JavaConversions._
+
+
+class PackageStorageSpec extends TestKit(ActorSystem("PackageStorageSpec"))
+  with FunSuiteLike
+  with ShouldMatchers
+  with ScalaFutures {
+
+  implicit val mat = ActorMaterializer()
+  implicit val config = system.settings.config
+
+  val configWithLocalStorage = ConfigFactory
+    .parseMap(Map("accessKey" -> "", "secretKey" -> "", "bucketId" -> ""))
+    .atPath("core.s3")
+
+  val localStorage = new PackageStorage()(system, mat, configWithLocalStorage).storage
+
+  test("uses local file storage if no s3 credentials are available") {
+    localStorage shouldBe a[LocalPackageStore]
+  }
+
+  test("uses s3 if if s3 credentials are defined") {
+    val configWithS3 = ConfigFactory
+      .parseMap(Map("accessKey" -> "fake", "secretKey" -> "fake", "bucketId" -> "bucket"))
+      .atPath("core.s3")
+
+    val storage = new PackageStorage()(system, mat, configWithS3).storage
+
+    storage shouldBe a[S3PackageStore]
+  }
+
+  test("builds a 2xx response when using LocalStorage") {
+    val packageModel =
+      Generators.PackageGen.sample.get.copy(uri = Uri("file:///proc/cpuinfo"))
+
+    val storage = new PackageStorage()(system, mat, configWithLocalStorage)
+
+    val f = storage.retrieveResponse(packageModel)
+
+    whenReady(f) { response =>
+      response.status shouldBe StatusCodes.OK
+    }
+  }
+}

--- a/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.core.storage
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.common.StrictForm
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest, Uri}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import akka.util.ByteString
+import com.typesafe.config.ConfigFactory
+import org.genivi.sota.core.IntegrationTest
+import org.genivi.sota.data.PackageIdGenerators
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FunSuiteLike, ShouldMatchers}
+
+import scala.concurrent.Future
+
+class S3PackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))
+  with FunSuiteLike
+  with ShouldMatchers
+  with ScalaFutures {
+
+  implicit val mat = ActorMaterializer()
+
+  implicit val patience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  val entity = HttpEntity(ByteString("""Não queiras, Lídia, edificar no espaço
+                                       |Que figuras futuro, ou prometer-te
+                                       |Amanhã. Cumpre-te hoje, não esperando.
+                                       |Tu mesma és tua vida.
+                                       |Não te destines, que não és futura.
+                                       |Quem sabe se, entre a taça que esvazias,
+                                       |E ela de novo enchida, não te a sorte
+                                       |Interpõe o abismo?""".stripMargin))
+
+  lazy val fileData = StrictForm.FileData(Some("filename.rpm"), entity)
+
+  lazy val credentials = S3PackageStore.loadCredentials(system.settings.config).get
+  lazy val s3 = new S3PackageStore(credentials)
+
+  test("stores a file on s3 with correct credentials", IntegrationTest) {
+    val packageId = PackageIdGenerators.genPackageId.sample.get
+
+    val f = s3.store(packageId, fileData)
+
+    whenReady(f) { case (uri, _, _) =>
+      uri.toString should startWith("https://rvi-sota-test.s3.eu-central-1.amazonaws.com/")
+    }
+  }
+
+  test("returns a public URL given a package URI", IntegrationTest) {
+    val packageId = PackageIdGenerators.genPackageId.sample.get
+    implicit val ec = system.dispatcher
+
+    def http(uri: Uri): Future[ByteString] = {
+      Http()
+        .singleRequest(HttpRequest(uri = uri))
+        .flatMap(_.entity.dataBytes.runFold(ByteString(""))(_ ++ _))
+    }
+
+    val f = for {
+      (uri, _, _) <- s3.store(packageId, fileData)
+      (s3Url, _) <- s3.retrieve(packageId, uri)
+      downloadContents <- http(s3Url)
+    } yield downloadContents
+
+    whenReady(f) { downloadContents =>
+      downloadContents shouldBe fileData.entity.data
+    }
+  }
+}

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -88,9 +88,9 @@ object SotaBuild extends Build {
 
   lazy val core = Project(id = "sota-core", base = file("core"))
     .settings( commonSettings ++ Migrations.settings ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.NscalaTime :+ Dependencies.Scalaz :+ Dependencies.Flyway,
-      testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi"),
-      testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi"),
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.NscalaTime :+ Dependencies.Scalaz :+ Dependencies.Flyway :+ Dependencies.AmazonS3,
+      testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi", "-l", "IntegrationTest"),
+      testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi", "-n", "IntegrationTest"),
       parallelExecution in Test := false,
       dockerExposedPorts := Seq(8080),
       flywayUrl := sys.env.get("CORE_DB_URL").orElse( sys.props.get("core.db.url") ).getOrElse("jdbc:mysql://localhost:3306/sota_core"),
@@ -211,4 +211,5 @@ object Dependencies {
 
   lazy val Rest = Akka ++ Slick
 
+  lazy val AmazonS3 =  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.69"
 }


### PR DESCRIPTION
Support local storage when no s3 credentials are available

Return 302/Found when client requests package stored on s3