### PR TITLE
Random test, added summary report

### DIFF
--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Random.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Random.scala
@@ -90,6 +90,8 @@ class Random extends ResourcePropSpec {
         Store.validStore.isValid(s) shouldBe true
       }
     } while (!accCoverage.fullCoverage)
+    info("Coverage:")
+    accCoverage.prettyPrint.foreach(info(_))
   }
 
 }

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Session.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Session.scala
@@ -14,17 +14,24 @@ import scala.concurrent.ExecutionContext
 case class Session(commands: List[Command], queries: List[Query]) {
 
   def coverageInfo: SessionCoverage =
-    SessionCoverage((commands ++ queries).map(_.getClass).toSet)
+    SessionCoverage(
+      (commands ++ queries).groupBy(_.getClass).map { case (klazz, cmds) => (klazz, cmds.size) }.toMap
+    )
 
 }
 
 /**
   * Endpoints (encompassing commands and queries) that are exercised.
   */
-case class SessionCoverage(covered: Set[Class[_]]) extends AnyVal {
+case class SessionCoverage(occurrences: Map[Class[_], Int]) extends AnyVal {
 
-  def merge(that: SessionCoverage): SessionCoverage =
-    SessionCoverage(covered.union(that.covered))
+  def covered: Set[Class[_]] = occurrences.keySet
+
+  def merge(that: SessionCoverage): SessionCoverage = {
+    SessionCoverage(
+      occurrences ++ that.occurrences.map { case (k,v) => k -> (v + occurrences.getOrElse(k,0)) }
+    )
+  }
 
   /**
     * Each position corresponds to an endpoint (command or query).
@@ -47,13 +54,50 @@ case class SessionCoverage(covered: Set[Class[_]]) extends AnyVal {
 
   def fullCoverage: Boolean = untested.isEmpty
 
+  def occurrencesCommands: Map[Class[_], Int] =
+    occurrences filter { case (klazz, _) => classOf[Command].isAssignableFrom(klazz) }
+
+  def occurrencesQueries: Map[Class[_], Int] =
+    occurrences filter { case (klazz, _) => classOf[Query].isAssignableFrom(klazz) }
+
+  /**
+   * For each entry (kind of command or query, number of occurrences) a line is produced,
+   * listing along the above a percentage with respect to all entries.
+   */
+  def prettyPrint: Seq[String] = {
+
+    import SessionCoverage.{Summary, SummaryLine}
+
+      def toSummary(occs: Map[Class[_], Int]): Summary = {
+        val totalOccs = occs.foldLeft(0) { (acc, entry) => val (klazz, num) = entry; acc + num }
+        val lines = occs.map({ case (klazz, num) => SummaryLine(klazz.getSimpleName, num) }).toSeq
+        Summary(lines, totalOccs)
+      }
+
+      def pp(s: Summary): Seq[String] = {
+        s.lines.sortBy(_.label).map(_.format(s.totalOccs))
+      }
+
+    ("Commands" +: pp(toSummary(occurrencesCommands))) ++ ("Queries" +: pp(toSummary(occurrencesQueries)))
+  }
+
 }
 
 object SessionCoverage {
 
+  case class SummaryLine(label: String, num: Int) {
+    def format(totalOccs: Int): String = {
+      val percent = (num * 100) / totalOccs.toDouble
+      val fmtPercent = f"${percent}%2.1f%%"
+      f"\t$label%25s:\t $num%4d ($fmtPercent%5s)"
+    }
+  }
+
+  case class Summary(lines: Seq[SummaryLine], totalOccs: Int)
+
   def testSpaceSize: Int = testSpace.length
 
-  def emptyCoverageInfo: SessionCoverage = SessionCoverage(Set.empty)
+  def emptyCoverageInfo: SessionCoverage = SessionCoverage(Map.empty)
 
   /**
     * Used to determine how much test coverage a Session achieves.


### PR DESCRIPTION
No functional change, just a more detailed summary report at the end of the `Random` test.

The number of commands and queries taking part in the test is reported, grouped by kind.

Example:
```
[info] Random:
[info] - Sessions (10 minutes, 3 seconds)
[info]   + Coverage: 
[info]   + Commands 
[info]   + 	             AddComponent:	  129 ( 5.6%) 
[info]   + 	                AddFilter:	  129 ( 5.6%) 
[info]   + 	       AddFilterToPackage:	   41 ( 1.8%) 
[info]   + 	               AddPackage:	  630 (27.4%) 
[info]   + 	               AddVehicle:	  654 (28.4%) 
[info]   + 	            EditComponent:	   55 ( 2.4%) 
[info]   + 	               EditFilter:	   61 ( 2.7%) 
[info]   + 	         InstallComponent:	   96 ( 4.2%) 
[info]   + 	           InstallPackage:	  389 (16.9%) 
[info]   + 	          RemoveComponent:	   36 ( 1.6%) 
[info]   + 	             RemoveFilter:	   50 ( 2.2%) 
[info]   + 	   RemoveFilterForPackage:	   12 ( 0.5%) 
[info]   + 	       UninstallComponent:	    4 ( 0.2%) 
[info]   + 	         UninstallPackage:	   14 ( 0.6%) 
[info]   + Queries 
[info]   + 	          ListComponents$:	  147 (12.1%) 
[info]   + 	        ListComponentsFor:	   75 ( 6.2%) 
[info]   + 	             ListFilters$:	   66 ( 5.5%) 
[info]   + 	           ListFiltersFor:	    6 ( 0.5%) 
[info]   + 	          ListPackagesFor:	    5 ( 0.4%) 
[info]   + 	    ListPackagesOnVehicle:	   68 ( 5.6%) 
[info]   + 	            ListVehicles$:	  150 (12.4%) 
[info]   + 	          ListVehiclesFor:	   42 ( 3.5%) 
[info]   + 	                  Resolve:	  651 (53.8%) 
[info] Run completed in 10 minutes, 20 seconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.

```