### PR TITLE
fuzzer extension to test how resolver reacts to bad requests

### DIFF
--- a/common-test/src/main/scala/org/genivi/sota/data/InvalidIdentGenerators.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/InvalidIdentGenerators.scala
@@ -1,0 +1,28 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.data
+
+import org.scalacheck.Gen
+
+trait InvalidIdentGenerators {
+
+  val EMPTY_STR = ""
+
+  val genSymbol: Gen[Char] =
+    Gen.oneOf('!', '@', '#', '$', '^', '&', '*', '(', ')')
+
+  val genInvalidIdent: Gen[String] =
+    for (
+      prefix   <- Gen.identifier;
+      suffix   <- Gen.identifier
+    ) yield prefix + getSymbol + suffix
+
+  def getInvalidIdent: String = genInvalidIdent.sample.getOrElse(getInvalidIdent)
+
+  def getSymbol: Char = genSymbol.sample.getOrElse(getSymbol)
+
+}
+
+object InvalidIdentGenerators extends InvalidIdentGenerators

--- a/common-test/src/main/scala/org/genivi/sota/data/PackageIdGenerators.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/PackageIdGenerators.scala
@@ -16,12 +16,16 @@ trait PackageIdGenerators {
     * @see [[https://www.scalacheck.org/]]
     */
 
+  val genPackageIdName: Gen[PackageId.Name] =
+    Gen.nonEmptyContainerOf[List, Char](Gen.alphaNumChar).map(cs => Refined.unsafeApply(cs.mkString))
+
+  val genPackageIdVersion: Gen[PackageId.Version] =
+    Gen.listOfN(3, Gen.choose(0, 999)).map(_.mkString(".")).map(Refined.unsafeApply) // scalastyle:ignore magic.number
+
   val genPackageId: Gen[PackageId] =
     for {
-      name    <- Gen.nonEmptyContainerOf[List, Char](Gen.alphaNumChar).map(cs => Refined.unsafeApply(cs.mkString))
-        : Gen[PackageId.Name]
-      version <- Gen.listOfN(3, Gen.choose(0, 999)).map(_.mkString("."))
-                   .map(Refined.unsafeApply): Gen[PackageId.Version]
+      name    <- genPackageIdName
+      version <- genPackageIdVersion
     } yield PackageId(name, version)
 
   implicit lazy val arbPackageId: Arbitrary[PackageId] =
@@ -30,3 +34,34 @@ trait PackageIdGenerators {
 }
 
 object PackageIdGenerators extends PackageIdGenerators
+
+/**
+  * Generators for invalid data are kept in dedicated scopes
+  * to rule out their use as implicits (impersonating valid ones).
+  */
+trait InvalidPackageIdGenerators extends InvalidIdentGenerators {
+
+  val genInvalidPackageIdName: Gen[PackageId.Name] =
+    genInvalidIdent map Refined.unsafeApply
+
+  def getInvalidPackageIdName: PackageId.Name =
+    genInvalidPackageIdName.sample.getOrElse(getInvalidPackageIdName)
+
+  val genInvalidPackageIdVersion: Gen[PackageId.Version] =
+    Gen.identifier.map(s => s + ".0").map(Refined.unsafeApply)
+
+  def getInvalidPackageIdVersion: PackageId.Version =
+    genInvalidPackageIdVersion.sample.getOrElse(getInvalidPackageIdVersion)
+
+  val genInvalidPackageId: Gen[PackageId] =
+    for {
+      name    <- genInvalidPackageIdName
+      version <- genInvalidPackageIdVersion
+    } yield PackageId(name, version)
+
+  def getInvalidPackageId: PackageId =
+    genInvalidPackageId.sample.getOrElse(getInvalidPackageId)
+
+}
+
+object InvalidPackageIdGenerators extends InvalidPackageIdGenerators

--- a/common-test/src/main/scala/org/genivi/sota/data/VehicleGenerators.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/VehicleGenerators.scala
@@ -24,9 +24,21 @@ object VehicleGenerators extends VinGenerators {
   implicit lazy val arbVehicle: Arbitrary[Vehicle] =
     Arbitrary(genVehicle)
 
+  def getVehicle: Vehicle = genVehicle.sample.getOrElse(getVehicle)
+
+}
+
+/**
+  * Generators for invalid data are kept in dedicated scopes
+  * to rule out their use as implicits (impersonating valid ones).
+  */
+object InvalidVehicleGenerators extends VinGenerators {
+
   val genInvalidVehicle: Gen[Vehicle] = for {
     // TODO: for now, just generate an invalid VIN with a valid namespace
     vin <- genInvalidVin
   } yield Vehicle(Namespaces.defaultNs, vin)
+
+  def getInvalidVehicle: Vehicle = genInvalidVehicle.sample.getOrElse(getInvalidVehicle)
 
 }

--- a/common-test/src/main/scala/org/genivi/sota/data/VinGenerators.scala
+++ b/common-test/src/main/scala/org/genivi/sota/data/VinGenerators.scala
@@ -33,21 +33,24 @@ trait VinGenerators {
   val genInvalidVin: Gen[Vehicle.Vin] = {
 
     val genTooLongVin: Gen[String] = for {
-      n  <- Gen.choose(18, 100)
+      n  <- Gen.choose(18, 100) // scalastyle:ignore magic.number
       cs <- Gen.listOfN(n, genVinChar)
     } yield cs.mkString
 
     val genTooShortVin: Gen[String] = for {
-      n  <- Gen.choose(1, 16)
+      n  <- Gen.choose(1, 16) // scalastyle:ignore magic.number
       cs <- Gen.listOfN(n, genVinChar)
     } yield cs.mkString
 
     val genNotAlphaNumVin: Gen[String] =
-      Gen.listOfN(17, Arbitrary.arbitrary[Char]).
+      Gen.listOfN(17, Arbitrary.arbitrary[Char]). // scalastyle:ignore magic.number
         suchThat(_.exists(c => !(c.isLetter || c.isDigit))).flatMap(_.mkString)
 
     Gen.oneOf(genTooLongVin, genTooShortVin, genNotAlphaNumVin)
        .map(Refined.unsafeApply)
   }
+
+  def getInvalidVin: Vehicle.Vin =
+    genInvalidVin.sample.getOrElse(getInvalidVin)
 
 }

--- a/common/src/main/scala/org/genivi/sota/rest/Errors.scala
+++ b/common/src/main/scala/org/genivi/sota/rest/Errors.scala
@@ -16,6 +16,7 @@ import io.circe.{Encoder, Decoder}
 object ErrorCodes {
   val InvalidEntity = new ErrorCode("invalid_entity")
   val DuplicateEntry = new ErrorCode("duplicate_entry")
+  val FilterNotFound = new ErrorCode("filter_not_found")
 }
 
 case class ErrorRepresentation( code: ErrorCode, description: String )

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ComponentGenerators.scala
@@ -1,5 +1,6 @@
 package org.genivi.sota.resolver.test
 
+import eu.timepit.refined.api.Refined
 import eu.timepit.refined.refineV
 import org.genivi.sota.data.Namespaces
 import org.genivi.sota.resolver.components.Component
@@ -32,3 +33,21 @@ trait ComponentGenerators extends Namespaces {
 }
 
 object ComponentGenerators extends ComponentGenerators
+
+trait InvalidComponentGenerators {
+
+  val genInvalidIdent: Gen[String] = Gen.uuid map (_.toString)
+
+  val genInvalidPartNumber: Gen[Component.PartNumber] = genInvalidIdent map (Refined.unsafeApply)
+
+  val genInvalidComponent: Gen[Component] = for {
+    partNumber  <- genInvalidPartNumber
+    desc        <- genInvalidIdent
+  } yield Component(Namespaces.defaultNs, partNumber, desc)
+
+  def getInvalidComponent: Component = genInvalidComponent.sample.getOrElse(getInvalidComponent)
+
+}
+
+object InvalidComponentGenerators extends InvalidComponentGenerators
+

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/FilterGenerators.scala
@@ -1,7 +1,7 @@
 package org.genivi.sota.resolver.test
 
 import eu.timepit.refined.api.Refined
-import org.genivi.sota.data.{Namespaces, SemanticVin}
+import org.genivi.sota.data.{InvalidIdentGenerators, Namespaces, PackageId, SemanticVin}
 import org.genivi.sota.resolver.components.Component
 import org.genivi.sota.resolver.filters._
 import org.genivi.sota.resolver.filters.FilterAST._
@@ -119,3 +119,28 @@ trait FilterGenerators {
 }
 
 object FilterGenerators extends FilterGenerators
+
+/**
+  * Generators for invalid data are kept in dedicated scopes
+  * to rule out their use as implicits (impersonating valid ones).
+  */
+object InvalidFilterGenerators extends InvalidIdentGenerators {
+
+  val genInvalidFilterName: Gen[Filter.Name] = genInvalidIdent map Refined.unsafeApply
+
+  def getInvalidFilterName: Filter.Name = genInvalidFilterName.sample.getOrElse(getInvalidFilterName)
+
+  def emptyFilterName: Filter.Name = Refined.unsafeApply(EMPTY_STR)
+
+  def emptyFilterExpression: Filter.Expression = Refined.unsafeApply(EMPTY_STR)
+
+  val genInvalidFilter: Gen[Filter] = for {
+    name <- genInvalidFilterName
+    expression <- Gen.const("INVALID") // TODO more varied (invalid) filter expressions
+  } yield Filter(Namespaces.defaultNs, name, Refined.unsafeApply(expression))
+
+  def getInvalidFilter: Filter = genInvalidFilter.sample.getOrElse(getInvalidFilter)
+
+  def emptyFilter: Filter = Filter(Namespaces.defaultNs, emptyFilterName, emptyFilterExpression)
+
+}

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageGenerators.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/PackageGenerators.scala
@@ -1,6 +1,6 @@
 package org.genivi.sota.resolver.test
 
-import org.genivi.sota.data.{Namespaces, PackageIdGenerators}
+import org.genivi.sota.data.{InvalidPackageIdGenerators, Namespaces, PackageIdGenerators}
 import org.genivi.sota.resolver.packages.Package
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -15,6 +15,26 @@ trait PackageGenerators extends PackageIdGenerators with Namespaces {
   implicit val arbPackage: Arbitrary[Package] =
     Arbitrary(genPackage)
 
+  def getPackage: Package = genPackage.sample.getOrElse(getPackage)
+
 }
 
 object PackageGenerators extends PackageGenerators
+
+/**
+  * Generators for invalid data are kept in dedicated scopes
+  * to rule out their use as implicits (impersonating valid ones).
+  */
+trait InvalidPackageGenerators extends InvalidPackageIdGenerators with Namespaces {
+
+  val genInvalidPackage: Gen[Package] = for {
+    id      <- genInvalidPackageId
+    desc    <- Gen.option(Arbitrary.arbitrary[String])
+    vendor  <- Gen.option(Gen.alphaStr)
+  } yield Package(defaultNs, id, desc, vendor)
+
+  def getInvalidPackage: Package = genInvalidPackage.sample.getOrElse(getInvalidPackage)
+
+}
+
+object InvalidPackageGenerators extends InvalidPackageGenerators

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Requests.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/Requests.scala
@@ -156,9 +156,16 @@ trait ComponentRequestsHttp {
   def listComponents: HttpRequest =
     Get(Resource.uri("components"))
 
+  def addComponent(cmpn: Component)
+                  (implicit ec: ExecutionContext): HttpRequest =
+    addComponent(cmpn.partNumber, cmpn.description)
+
   def addComponent(part: Component.PartNumber, desc: String)
                   (implicit ec: ExecutionContext): HttpRequest =
     Put(Resource.uri("components", part.get), Component.DescriptionWrapper(desc))
+
+  def deleteComponent(cmpn: Component): HttpRequest =
+    deleteComponent(cmpn.partNumber)
 
   def deleteComponent(part: Component.PartNumber): HttpRequest =
     Delete(Resource.uri("components", part.get))

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/VehiclesResourceSpec.scala
@@ -24,6 +24,7 @@ import org.scalacheck._
 class VehiclesResourcePropSpec extends ResourcePropSpec
     with PackageGenerators{
   import org.genivi.sota.data.VehicleGenerators._
+  import org.genivi.sota.data.InvalidVehicleGenerators
 
   val vehicles = "vehicles"
 
@@ -34,7 +35,7 @@ class VehiclesResourcePropSpec extends ResourcePropSpec
   }
 
   property("Invalid vehicles are rejected") {
-    forAll(genInvalidVehicle) { vehicle: Vehicle =>
+    forAll(InvalidVehicleGenerators.genInvalidVehicle) { vehicle: Vehicle =>
       addVehicle(vehicle.vin) ~> route ~> check {
         status shouldBe StatusCodes.BadRequest
       }

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Query.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Query.scala
@@ -162,7 +162,7 @@ object Query extends
           Store.pickPackageWithFilter.runA(s) map { case (pkg, flt) => ListFiltersFor(pkg)  }
         )),
 
-        (if (pkgs > 0) 50 else 0,
+        (if (pkgs > 0) 10 else 0,
           Store.pickPackage.runA(s).map(pkg => Resolve(pkg.id)))
       ))
     } yield qry

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Result.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/random/Result.scala
@@ -25,7 +25,11 @@ final case class  Failure(c: ErrorCode)                                    exten
 /**
   * A [[Semantics]] with [[Success]] makes [[org.genivi.sota.resolver.test.Random]]
   * check only the response's status code. To also check the response's body against expected results,
-  * provide instead another Success case class that carries those expected results.
+  * provide instead:
+  * <ul>
+  * <li>another Success case class that carries those expected results; or</li>
+  * <li>a [[Failure]]</li>
+  * </ul>
   */
 final case object Success                                                  extends Result
 final case class  SuccessVehicles(vehs : Set[Vehicle])                     extends Result


### PR DESCRIPTION
Current limitations ( quoting from https://advancedtelematic.atlassian.net/browse/PRO-344 )
* only "single shot" bad requests are generated. For example, attempt to add vehicle with invalid vin

Improvements over previous versions:
* Stats track each kind of "bad request" separately. Full test coverage requires at least one instance of each kind of bad request to be included.

Regarding "single-shot bad requests" vs "sequences of requests" (possibly well-formed, when each request is considered on its own) could also be of interest, provided they trigger an error condition. For example, two requests attempting to add the same vehicle (for a valid vin). Very unlikely the (non-guided) generator will pick the same vin for different `AddVehicle` instances.
