### PR TITLE
JStrGen now produces non-numeric strings (identifiers in fact)

### DIFF
--- a/core/src/test/scala/org/genivi/sota/core/jsonrpc/JsonGen.scala
+++ b/core/src/test/scala/org/genivi/sota/core/jsonrpc/JsonGen.scala
@@ -11,7 +11,7 @@ trait JsonGen {
   import org.scalacheck.Gen
 
   val JBooleanGen : Gen[Json] = Gen.oneOf(true, false).map( Json.fromBoolean )
-  val JStrGen : Gen[Json] = Arbitrary.arbString.arbitrary.map( Json.fromString )
+  val JStrGen : Gen[Json] = Gen.identifier.map( Json.fromString )
   val JNumGen : Gen[Json] = Arbitrary.arbInt.arbitrary.map( Json.fromInt )
   val JNullGen: Gen[Json] = Gen.const( Json.Null )
 


### PR DESCRIPTION
Before this PR, a test could fail (shown below) although the subject under test (SUT) was correct.

- The test assumes `Arbitrary.arbString.arbitrary` to always produce (non-numeric) strings. 
- A string containing an Int was valid input for the SUT thus making the test fail.

This PR leaves the test as-is. This PR changes the generator in question to comply with the test's expectations.

- Test:
```
    forAll( Gen.oneOf(JBooleanGen, JStrGen, JNullGen) ) { (params: Json) =>
      Post("/",  ('jsonrpc ->> "2.0") :: ('method ->> "one") :: ('params ->> params) :: ('id ->> 1) :: HNil ) ~> underTest ~> check {
        status shouldBe StatusCodes.OK
        responseAs[ErrorResponse].error shouldBe PredefinedErrors.InvalidParams
      }
    }
```
- Excerpt from failing build:
```
[Invalid params] org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation.
  Message: Could not unmarshal response to type 'org.genivi.sota.core.jsonrpc.ErrorResponse' for `responseAs` assertion: DecodingFailure(Attempt to decode value on failed cursor, List(El(DownField(error),false,false)))

Response was: HttpResponse(200 OK,List(),HttpEntity.Strict(application/json,{"jsonrpc":"2.0","result":"fn1: 5","id":1}),HttpProtocol(HTTP/1.1))
  Location: (JsonRpcDirectivesSpec.scala:17)
  Occurred when passed generated values (
    arg0 = "５"
  )
	at org.scalatest.prop.Checkers$.doCheck(Checkers.scala:428)
	at org.scalatest.prop.GeneratorDrivenPropertyChecks$class.forAll(GeneratorDrivenPropertyChecks.scala:914)
	at org.genivi.sota.core.jsonrpc.JsonRpcDirectivesSpec.forAll(JsonRpcDirectivesSpec.scala:17)
	at org.genivi.sota.core.jsonrpc.JsonRpcDirectivesSpec$$anonfun$4.apply$mcV$sp(JsonRpcDirectivesSpec.scala:73)
	at org.genivi.sota.core.jsonrpc.JsonRpcDirectivesSpec$$anonfun$4.apply(JsonRpcDirectivesSpec.scala:65)
	at org.genivi.sota.core.jsonrpc.JsonRpcDirectivesSpec$$anonfun$4.apply(JsonRpcDirectivesSpec.scala:65)
	at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
```
- Failing build:
https://teamcity.advancedtelematic.com/viewLog.html?buildId=4169&buildTypeId=JlrSota_SotaServer