### PR TITLE
Add new endpoint to change package install pos

### DIFF
--- a/common/src/main/scala/org/genivi/sota/http/HealthResource.scala
+++ b/common/src/main/scala/org/genivi/sota/http/HealthResource.scala
@@ -1,0 +1,20 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.http
+
+import akka.http.scaladsl.server.Directives
+import slick.driver.MySQLDriver.api._
+
+import scala.concurrent.ExecutionContext
+
+class HealthResource(db: Database)(implicit val ec: ExecutionContext) {
+  import Directives._
+
+  val route = path("health") {
+    val query = sql"SELECT 1 FROM dual ".as[Int]
+    val f = db.run(query).map(_ => "OK")
+    complete(f)
+  }
+}

--- a/common/src/main/scala/org/genivi/sota/http/SotaDirectives.scala
+++ b/common/src/main/scala/org/genivi/sota/http/SotaDirectives.scala
@@ -1,0 +1,17 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+package org.genivi.sota.http
+
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.{Directive0, Directives}
+
+object SotaDirectives {
+  import Directives._
+
+  def versionHeaders(version: String): Directive0 = {
+    val header = RawHeader("x-ats-version", version)
+    respondWithHeader(header)
+  }
+}

--- a/common/src/main/scala/org/genivi/sota/marshalling/CirceInstances.scala
+++ b/common/src/main/scala/org/genivi/sota/marshalling/CirceInstances.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.model.Uri
 import cats.data.Xor
 import eu.timepit.refined.refineV
 import eu.timepit.refined.api.{Refined, Validate}
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import io.circe._
 import org.joda.time.{DateTime, Interval}
 import org.joda.time.format.{DateTimeFormatter, ISODateTimeFormat}
 
@@ -34,7 +34,7 @@ trait CirceInstances {
         case Right(r) => r
       })
 
-  implicit def mapDecoder[K, V](implicit keyDecoder: Decoder[K], valueDecoder: Decoder[V]): Decoder[Map[K, V]] =
+  implicit def refinedMapDecoder[K <: Refined[_, _], V](implicit keyDecoder: Decoder[K], valueDecoder: Decoder[V]): Decoder[Map[K, V]] =
     Decoder[Seq[(K, V)]].map(_.toMap)
 
   implicit def refinedEncoder[T, P](implicit encoder: Encoder[T]): Encoder[Refined[T, P]] =
@@ -86,10 +86,8 @@ trait CirceInstances {
   implicit val intervalEncoder : Encoder[Interval] = Encoder[String].contramap(_.toString)
   implicit val intervalDecoder : Decoder[Interval] = Decoder[String].map(Interval.parse)
 
-  implicit def mapEncoder[K, V](implicit keyEncoder: Encoder[K], valueEncoder: Encoder[V]): Encoder[Map[K, V]] =
+  implicit def mapRefinedEncoder[K <: Refined[_, _], V](implicit keyEncoder: Encoder[K], valueEncoder: Encoder[V]): Encoder[Map[K, V]] =
     Encoder[Seq[(K, V)]].contramap((m: Map[K, V]) => m.toSeq)
-
-
 }
 
 object CirceInstances extends CirceInstances

--- a/core/src/main/resources/db/migration/V6__add_update_req_install_pos.sql
+++ b/core/src/main/resources/db/migration/V6__add_update_req_install_pos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE UpdateRequest
+ADD install_pos int NOT NULL
+;

--- a/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
@@ -38,7 +38,8 @@ case class UpdateRequest(
   priority: Int,
   signature: String,
   description: Option[String],
-  requestConfirmation: Boolean)
+  requestConfirmation: Boolean,
+  installPos: Int = 0)
 
 object UpdateRequest {
 

--- a/core/src/main/scala/org/genivi/sota/core/data/client/PendingUpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/client/PendingUpdateRequest.scala
@@ -12,12 +12,12 @@ import org.genivi.sota.data.PackageId
 import org.joda.time.{DateTime, Interval}
 import scala.language.implicitConversions
 
-case class PendingUpdateRequest(requestId: UUID, packageId: PackageId, createdAt: DateTime)
+case class PendingUpdateRequest(requestId: UUID, packageId: PackageId, installPos: Int, createdAt: DateTime)
 
 object PendingUpdateRequest {
   implicit def toResponseEncoder: ResponseEncoder[PendingUpdateRequest, UpdateRequest] =
     ResponseEncoder { u =>
-      PendingUpdateRequest(u.id, u.packageId, u.creationTime)
+      PendingUpdateRequest(u.id, u.packageId, u.installPos, u.creationTime)
     }
 }
 

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -44,6 +44,7 @@ object UpdateRequests {
     def signature = column[String]("signature")
     def description = column[String]("description")
     def requestConfirmation = column[Boolean]("request_confirmation")
+    def installPos = column[Int]("install_pos")
     // scalastyle:on
 
     import com.github.nscala_time.time.Imports._
@@ -62,14 +63,12 @@ object UpdateRequests {
     // scalastyle:off public.methods.have.type
     // scalastyle:off method.name
     def * = (id, namespace, packageName, packageVersion, creationTime, startAfter, finishBefore,
-             priority, signature, description.?, requestConfirmation).shaped <>
-      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11),
+             priority, signature, description.?, requestConfirmation, installPos).shaped <>
+      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11, x._12),
       (x: UpdateRequest) => Some((x.id, x.namespace, x.packageId.name, x.packageId.version, x.creationTime,
                                   x.periodOfValidity.start, x.periodOfValidity.end, x.priority,
-                                  x.signature, x.description, x.requestConfirmation)))
+                                  x.signature, x.description, x.requestConfirmation, x.installPos)))
     // scalastyle:on
-
-
   }
 
   /**

--- a/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
@@ -26,7 +26,7 @@ import org.genivi.sota.core.data.{Package, UpdateSpec, UpdateStatus}
 import org.genivi.sota.core.db.UpdateSpecs
 import org.genivi.sota.core.resolver.ConnectivityClient
 import org.genivi.sota.core.storage.S3PackageStore
-import org.genivi.sota.core.transfer.InstalledPackagesUpdate
+import org.genivi.sota.core.transfer.VehicleUpdates
 import org.genivi.sota.data.Vehicle
 import org.joda.time.DateTime
 
@@ -188,7 +188,7 @@ class TransferProtocolActor(db: Database, rviClient: ConnectivityClient,
       log.debug(s"Install report received from $vin: ${update.update_id} installed with ${update.operation_results}")
       updates.find(_.request.id == update.update_id) match {
         case Some(spec) =>
-          InstalledPackagesUpdate.reportInstall(vin, update)(dispatcher, db)
+          VehicleUpdates.reportInstall(vin, update)(dispatcher, db)
           rviClient.sendMessage(services.getpackages, io.circe.Json.Null, ttl())
           context.stop( self )
         case None => log.error(s"Update ${update.update_id} for corresponding install report does not exist!")

--- a/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
@@ -8,7 +8,7 @@ import eu.timepit.refined.api.Refined
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.db.{Packages, UpdateSpecs, Vehicles}
 import org.genivi.sota.core.resolver.DefaultConnectivity
-import org.genivi.sota.core.transfer.{DefaultUpdateNotifier, InstalledPackagesUpdate}
+import org.genivi.sota.core.transfer.{DefaultUpdateNotifier, VehicleUpdates}
 import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.Namespaces
 import org.genivi.sota.data.{PackageId, Vehicle, VehicleGenerators}
@@ -122,7 +122,7 @@ class UpdateServiceSpec extends PropSpec
     val f = for {
       (vehicle, packageM) <- db.run(dbSetup)
       updateRequest <- service.queueVehicleUpdate(vehicle.namespace, vehicle.vin, packageM.id)
-      queuedPackages <- db.run(InstalledPackagesUpdate.findPendingPackageIdsFor(vehicle.namespace, vehicle.vin))
+      queuedPackages <- db.run(VehicleUpdates.findPendingPackageIdsFor(vehicle.namespace, vehicle.vin))
     } yield (updateRequest, queuedPackages)
 
     whenReady(f) { case (updateRequest, queuedPackages) =>

--- a/core/src/test/scala/org/genivi/sota/core/resolver/ExternalResolverClientSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/resolver/ExternalResolverClientSpec.scala
@@ -10,7 +10,7 @@ import eu.timepit.refined.api.Refined
 import io.circe.Json
 import io.circe.jawn._
 import org.genivi.sota.data.{PackageId, Vehicle}
-import org.genivi.sota.marshalling.CirceMarshallingSupport
+import io.circe.generic.auto._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
@@ -48,9 +48,8 @@ class ExternalResolverClientSpec extends PropSpec with Matchers with BeforeAndAf
     Map(Refined.unsafeApply("V1NBEAGLEB0ARD000") -> Set(PackageId(Refined.unsafeApply("rust"), Refined.unsafeApply("23.5.2"))))
 
   property("parse the external resolver's response") {
-
-    decode[Map[Vehicle.Vin, Set[PackageId]]](s) shouldBe Xor.Right(m)
-
+    import org.genivi.sota.marshalling.CirceInstances.refinedMapDecoder
+    decode[Map[Vehicle.Vin, Set[PackageId]]](s)(refinedMapDecoder) shouldBe Xor.Right(m)
   }
 
   val resp: HttpResponse = HttpResponse(entity = HttpEntity(`application/json`, s))
@@ -64,7 +63,6 @@ class ExternalResolverClientSpec extends PropSpec with Matchers with BeforeAndAf
   }
 
   property("parse from a HttpResponse as a Map") {
-
     ScalaFutures.whenReady(Unmarshal(resp.entity).to[Map[Vehicle.Vin, Set[PackageId]]]) { m2 =>
       m2 shouldBe m
     }

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -84,6 +84,7 @@ object SotaBuild extends Build {
     ))
     .dependsOn(common, commonData, commonTest % "test")
     .enablePlugins(Packaging.plugins :+ BuildInfoPlugin :_*)
+    .enablePlugins(BuildInfoPlugin)
     .settings(Publish.settings)
 
   lazy val core = Project(id = "sota-core", base = file("core"))
@@ -102,6 +103,7 @@ object SotaBuild extends Build {
     .configs(IntegrationTests, UnitTests)
     .dependsOn(common, commonData, commonTest % "test")
     .enablePlugins(Packaging.plugins: _*)
+    .enablePlugins(BuildInfoPlugin)
     .settings(Publish.settings)
 
   import play.sbt.Play.autoImport._

--- a/web-server/test/APIFunTests.scala
+++ b/web-server/test/APIFunTests.scala
@@ -14,7 +14,7 @@ import org.joda.time.format.DateTimeFormat
 import org.scalatest.Tag
 import org.scalatestplus.play._
 import play.api.Play
-import play.api.libs.ws.{WSResponse, WS}
+import play.api.libs.ws.{WS, WSResponse}
 import play.api.mvc.{Cookie, Cookies}
 import play.api.test.Helpers._
 import io.circe._
@@ -22,6 +22,7 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import io.circe.parser._
+import org.genivi.sota.data.Vehicle.Vin
 
 object APITests extends Tag("APITests")
 
@@ -379,11 +380,14 @@ class APIFunTests extends PlaySpec with OneServerPerSuite {
   "test list of vins affected by update" taggedAs APITests in {
     val response = makeRequest("resolve/" + testPackageName + "/" + testPackageVersion, GET)
     response.status mustBe OK
-    import org.genivi.sota.marshalling.CirceInstances.mapDecoder
-    val jsonResponse = decode[Map[String, Seq[PackageId]]](response.body)
+    import org.genivi.sota.marshalling.CirceInstances._
+
+    println(response.body)
+
+    val jsonResponse = decode[Map[Vin, Seq[PackageId]]](response.body)(refinedMapDecoder)
     jsonResponse.toOption match {
-      case Some(resp : Map[String, Seq[PackageId]]) => resp.toList.length mustBe 1
-                                                       resp.head._1 mustBe testVin
+      case Some(resp : Map[Vin, Seq[PackageId]]) => resp.toList.length mustBe 1
+                                                       resp.head._1.get mustBe testVin
                                                        resp.head._2.length mustBe 1
                                                        resp.head._2.head.name mustBe testPackageName
                                                        resp.head._2.head.version mustBe testPackageVersion


### PR DESCRIPTION
This allows the api client to set the install order of a particular set
of updates to a specific vehicle.

The new endpoint is available at `api/v1/vehicle_updates/vin/order`,
this accepts a `PUT` request with the format:

     {
        "0": "UUID for update request",
        "1": "UUID for update request"
        // ...
     }

The packages will be delivered in this order when the client queries the
`api/v1/vehicle_updates` API. The install pos will be returned in a new
attribute that should be used by the client to sort updates to install.

    GET api/v1/vehicle_updates/

    [{
      "createdAt": "2016-04-27T02:00:00.000+02:00",
      "installPos": 0,
      "packageId": {
        "name": "pkgname",
        "version": "1.0.0"
      },
      "requestId": "41078e2f-b8c5-4fda-87fa-1f4761413553"
    }]