### PR TITLE
Enforce uniqueness of Vehicle.Vin

### DIFF
--- a/core/src/main/resources/db/migration/V8__unique_vins.sql
+++ b/core/src/main/resources/db/migration/V8__unique_vins.sql
@@ -1,0 +1,1 @@
+ALTER TABLE Vehicle ADD UNIQUE unique_vin(vin);

--- a/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
@@ -75,8 +75,8 @@ object OperationResults {
     * @param vin The VIN for which all OperationResults should be returned
     * @return all OperationResults associated with the given VIN
     */
-  def byVin(ns: Namespace, vin: Vehicle.Vin)(implicit ec: ExecutionContext): DBIO[Seq[OperationResult]] =
-    all.filter(r => r.namespace === ns && r.vin === vin).result
+  def byVin(vin: Vehicle.Vin)(implicit ec: ExecutionContext): DBIO[Seq[OperationResult]] =
+    all.filter(_.vin === vin).result
 
   /**
    * Add a new package update. Package updated specify a specific package at a

--- a/core/src/main/scala/org/genivi/sota/core/db/Vehicles.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Vehicles.scala
@@ -89,10 +89,10 @@ object Vehicles {
   def searchByRegex(ns: Namespace, reg:String): Query[VehicleTable, Vehicle, Seq] =
     all(ns).filter(v => regex(v.vin, reg))
 
-  def updateLastSeen(vehicle: Vehicle, lastSeen: DateTime = DateTime.now)
+  def updateLastSeen(vin: Vehicle.Vin, lastSeen: DateTime = DateTime.now)
                     (implicit ec: ExecutionContext): DBIO[DateTime] = {
     vehicles
-      .filter(v => v.namespace === vehicle.namespace && v.vin === vehicle.vin)
+      .filter(_.vin === vin)
       .map(_.lastSeen)
       .update(Some(lastSeen))
       .map(_ => lastSeen)

--- a/core/src/main/scala/org/genivi/sota/core/transfer/VehicleUpdates.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/VehicleUpdates.scala
@@ -76,10 +76,10 @@ object VehicleUpdates {
     db.run(dbIO)
   }
 
-  def findPendingPackageIdsFor(ns: Namespace, vin: Vehicle.Vin)
+  def findPendingPackageIdsFor(vin: Vehicle.Vin)
                               (implicit db: Database, ec: ExecutionContext) : DBIO[Seq[UpdateRequest]] = {
     updateSpecs
-      .filter(r => r.namespace === ns && r.vin === vin)
+      .filter(_.vin === vin)
       .filter(_.status.inSet(List(UpdateStatus.InFlight, UpdateStatus.Pending)))
       .join(updateRequests).on(_.requestId === _.id)
       .sortBy(r => (r._2.installPos.asc, r._2.creationTime.asc))

--- a/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
@@ -122,7 +122,7 @@ class UpdateServiceSpec extends PropSpec
     val f = for {
       (vehicle, packageM) <- db.run(dbSetup)
       updateRequest <- service.queueVehicleUpdate(vehicle.namespace, vehicle.vin, packageM.id)
-      queuedPackages <- db.run(VehicleUpdates.findPendingPackageIdsFor(vehicle.namespace, vehicle.vin))
+      queuedPackages <- db.run(VehicleUpdates.findPendingPackageIdsFor(vehicle.vin))
     } yield (updateRequest, queuedPackages)
 
     whenReady(f) { case (updateRequest, queuedPackages) =>

--- a/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
@@ -72,7 +72,7 @@ class VehicleUpdatesSpec extends FunSuite
     val dbIO = for {
       (_, vehicle, updateRequest0) <- createUpdateSpecAction()
       (_, updateRequest1) <- createUpdateSpecFor(vehicle, _.copy(installPos = 2))
-      result <- findPendingPackageIdsFor(defaultNamespace, vehicle.vin)
+      result <- findPendingPackageIdsFor(vehicle.vin)
     } yield (result, updateRequest0, updateRequest1)
 
     whenReady(db.run(dbIO)) { case (result, updateRequest0, updateRequest1)  =>
@@ -94,7 +94,7 @@ class VehicleUpdatesSpec extends FunSuite
       (pck, vehicle, spec0) <- createUpdateSpecAction()
       (_, spec1) <- createUpdateSpecFor(vehicle)
       _ <- persistInstallOrder(vehicle.vin, List(spec0.request.id, spec1.request.id))
-      dbSpecs <- findPendingPackageIdsFor(defaultNamespace, vehicle.vin)
+      dbSpecs <- findPendingPackageIdsFor(vehicle.vin)
     } yield (dbSpecs, spec0, spec1)
 
     whenReady(db.run(dbIO)) { case (Seq(dbSpec0, dbSpec1), spec0, spec1) =>


### PR DESCRIPTION
This means we don't need the namespace for certain operations, mainly
when these operations are requested from a vehicle.