### PR TITLE
PRO-436 upgrade to Flyway 4.0.3

### DIFF
--- a/common/src/main/scala/org/genivi/sota/db/BootMigrations.scala
+++ b/common/src/main/scala/org/genivi/sota/db/BootMigrations.scala
@@ -1,0 +1,31 @@
+/**
+ * Copyright: Copyright (C) 2015, Jaguar Land Rover
+ * License: MPL-2.0
+ */
+
+package org.genivi.sota.db
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.flywaydb.core.Flyway
+import org.slf4j.LoggerFactory
+
+trait BootMigrations {
+  private val _migrateConfig = ConfigFactory.load()
+
+  private val _migrateLog = LoggerFactory.getLogger(this.getClass)
+
+  // Database migrations
+  if (_migrateConfig.getBoolean("database.migrate")) {
+    _migrateLog.info("Running migrations")
+
+    val url = _migrateConfig.getString("database.url")
+    val user = _migrateConfig.getString("database.properties.user")
+    val password = _migrateConfig.getString("database.properties.password")
+
+    val flyway = new Flyway
+    flyway.setDataSource(url, user, password)
+    val count = flyway.migrate()
+
+    _migrateLog.info(s"Ran $count migrations")
+  }
+}

--- a/deploy/migration/Dockerfile
+++ b/deploy/migration/Dockerfile
@@ -1,6 +1,6 @@
-FROM java:8
+FROM alpine:3.4
 
-RUN apt-get update && apt-get install -y mysql-client
+RUN apk --update add mysql-client git curl bash coreutils tar openjdk8-jre-base
 
 WORKDIR /migrations
 
@@ -8,11 +8,11 @@ RUN git clone https://github.com/advancedtelematic/rvi_sota_server.git
 
 RUN \
   mkdir flyway && \
-  curl -O https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/3.2.1/flyway-commandline-3.2.1.tar.gz
+  curl -o flyway.tgz https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/4.0.3/flyway-commandline-4.0.3.tar.gz
 
-RUN echo "0750456fff19128f3d42e45d2e2a6e318ecb947c flyway-commandline-3.2.1.tar.gz" | sha1sum -c -
+RUN echo "a9819bd1fddf4ef96885665d67b0248ba9b74bd4 flyway.tgz" | sha1sum -c -
 
-RUN tar xvf flyway-commandline-3.2.1.tar.gz -C flyway --strip-components=1
+RUN tar zxvf flyway.tgz -C flyway --strip-components=1
 
 ADD entrypoint.sh /migrations/entrypoint.sh
 

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/Boot.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/Boot.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.{Directive1, Directives, Route}
 import akka.stream.ActorMaterializer
 import org.genivi.sota.data.Namespace
+import org.genivi.sota.db.BootMigrations
 import org.genivi.sota.http._
 import org.genivi.sota.rest.Handlers.{exceptionHandler, rejectionHandler}
 import org.slf4j.LoggerFactory
@@ -34,7 +35,7 @@ class Routing(namespaceExtractor: Directive1[Namespace])
   }
 }
 
-object Boot extends App with Directives {
+object Boot extends App with Directives with BootMigrations {
   import LogDirectives._
   import VersionDirectives._
 
@@ -43,18 +44,7 @@ object Boot extends App with Directives {
   implicit val exec = system.dispatcher
   implicit val log = LoggerFactory.getLogger(this.getClass)
   implicit val db = Database.forConfig("database")
-  val config = system.settings.config
-
-  if (config.getBoolean("database.migrate")) {
-    val url = config.getString("database.url")
-    val user = config.getString("database.properties.user")
-    val password = config.getString("database.properties.password")
-
-    import org.flywaydb.core.Flyway
-    val flyway = new Flyway
-    flyway.setDataSource(url, user, password)
-    flyway.migrate()
-  }
+  lazy val config = system.settings.config
 
   lazy val version = {
     val bi = org.genivi.sota.device_registry.BuildInfo

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -258,7 +258,7 @@ object Dependencies {
 
   lazy val ScalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
 
-  lazy val Flyway = "org.flywaydb" % "flyway-core" % "3.2.1"
+  lazy val Flyway = "org.flywaydb" % "flyway-core" % "4.0.3"
 
   lazy val TestFrameworks = Seq( ScalaTest, ScalaCheck )
 


### PR DESCRIPTION
- Flyway 4.0.1 got (slightly) more helpful when computing checksums, https://github.com/flyway/flyway/issues/253
- and also:

> This version comes with a new metadata table format. 
> Migration is transparent and automatic on first run of any Flyway command. 
> This new format is not compatible with older Flyway versions.

We're upgrading from Flyway 3.2.1. Release notes: https://flywaydb.org/documentation/releaseNotes

/cc @simao The CI build for PR uses an empty database on which most migrations succeed. Instead, a database with all tables populated would catch migration errors before they reach production servers.
