### PR TITLE
map port 9000 for webserver, add composer up scripts

### DIFF
--- a/deploy/docker-compose/server-bare.yml
+++ b/deploy/docker-compose/server-bare.yml
@@ -48,7 +48,7 @@ services:
       - resolver
       - core
     ports:
-      - 80:9000
+      - 9000:9000
     expose:
       - 9000
     environment:

--- a/deploy/docker-compose/server-rvi-client.yml
+++ b/deploy/docker-compose/server-rvi-client.yml
@@ -65,7 +65,7 @@ services:
       - resolver
       - core
     ports:
-      - 80:9000
+      - 9000:9000
     expose:
       - 9000
     environment:

--- a/deploy/docker-compose/server-rvi.yml
+++ b/deploy/docker-compose/server-rvi.yml
@@ -65,7 +65,7 @@ services:
       - resolver
       - core
     ports:
-      - 80:9000
+      - 9000:9000
     expose:
       - 9000
     environment:

--- a/deploy/down-server-bare.sh
+++ b/deploy/down-server-bare.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eu
+
+docker-compose -p sota -f docker-compose/server-bare.yml down &

--- a/deploy/pull-all.sh
+++ b/deploy/pull-all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+docker-compose -p sota -f docker-compose/server-bare.yml pull
+docker-compose -p sota -f docker-compose/server-rvi.yml  pull
+docker-compose -p sota -f docker-compose/server-rvi-client.yml pull

--- a/deploy/up-server-bare.sh
+++ b/deploy/up-server-bare.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+docker-compose -p sota -f docker-compose/server-bare.yml up -d mysql &
+sleep 120
+docker-compose -p sota -f docker-compose/server-bare.yml up &
+


### PR DESCRIPTION
- The Play application binds port 9000, not 80.
- Script that follows correct start-up order (for `server-bare.yml`)

TODOs: 
- Start-up script for `server-rvi.yml`
- ditto for `server-rvi-client.yml`

Question: what start-up order should they follow?

TODO: Lastly, update https://github.com/advancedtelematic/rvi_sota_server/blob/master/docs/_posts/2016-05-18-deployment-with-dockercompose.adoc
