### PR TITLE
setting the install order of pending campaigns for one VIN also affects all other VIN-s

### DIFF
--- a/core/src/main/resources/db/migration/V10__add_update_spec_install_pos.sql
+++ b/core/src/main/resources/db/migration/V10__add_update_spec_install_pos.sql
@@ -1,0 +1,7 @@
+ALTER TABLE UpdateRequest
+DROP COLUMN install_pos
+;
+
+ALTER TABLE UpdateSpec
+ADD install_pos int NOT NULL
+;

--- a/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
@@ -29,7 +29,7 @@ import org.genivi.sota.core.db.UpdateSpecs
  * @param signature Signature for this updates Id
  * @param description A descriptive text of the available update.
  * @param requestConfirmation Flag to indicate if a user confirmation of the package is required.
- * @param installPos
+ * @param installPos Derived from the corresponding field in [[UpdateSpec]]
  */
 case class UpdateRequest(
   id: UUID,
@@ -89,12 +89,15 @@ import UpdateStatus._
   * @param vin The vehicle to which these updates should be applied
   * @param status The status of the update
   * @param dependencies The packages to be installed
+  * @param installPos Position in the installation queue, zero-based
   */
 case class UpdateSpec(
   request: UpdateRequest,
   vin: Vehicle.Vin,
   status: UpdateStatus,
-  dependencies: Set[Package] ) {
+  dependencies: Set[Package],
+  installPos: Int = 0 /* zero-based */
+) {
 
   def namespace: Namespace = request.namespace
 

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -44,7 +44,6 @@ object UpdateRequests {
     def signature = column[String]("signature")
     def description = column[String]("description")
     def requestConfirmation = column[Boolean]("request_confirmation")
-    def installPos = column[Int]("install_pos")
 
     import com.github.nscala_time.time.Imports._
     import shapeless._
@@ -63,11 +62,11 @@ object UpdateRequests {
     def pk = primaryKey("pk_UpdateRequest", (id))
 
     def * = (id, namespace, packageName, packageVersion, creationTime, startAfter, finishBefore,
-             priority, signature, description.?, requestConfirmation, installPos).shaped <>
-      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11, x._12),
+             priority, signature, description.?, requestConfirmation).shaped <>
+      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11),
       (x: UpdateRequest) => Some((x.id, x.namespace, x.packageId.name, x.packageId.version, x.creationTime,
                                   x.periodOfValidity.start, x.periodOfValidity.end, x.priority,
-                                  x.signature, x.description, x.requestConfirmation, x.installPos)))
+                                  x.signature, x.description, x.requestConfirmation)))
   }
   // scalastyle:on
 

--- a/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
@@ -34,13 +34,14 @@ trait UpdateResourcesDatabaseSpec {
 
   import Generators._
 
-  def createUpdateSpecFor(vehicle: Vehicle, transformFn: UpdateRequest => UpdateRequest = identity)
+  def createUpdateSpecFor(vehicle: Vehicle, installPos: Int = 0)
                          (implicit ec: ExecutionContext): DBIO[(Package, UpdateSpec)] = {
-    val (packageModel, updateSpec) = genUpdateSpecFor(vehicle).sample.get
+    val (packageModel, updateSpec0) = genUpdateSpecFor(vehicle).sample.get
+    val updateSpec = updateSpec0.copy(installPos = installPos)
 
     val dbIO = DBIO.seq(
       Packages.create(packageModel),
-      UpdateRequests.persist(transformFn(updateSpec.request)),
+      UpdateRequests.persist(updateSpec.request),
       UpdateSpecs.persist(updateSpec)
     )
 

--- a/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
@@ -70,19 +70,19 @@ class VehicleUpdatesSpec extends FunSuite
 
   test("when multiple packages are pending sorted by installPos") {
     val dbIO = for {
-      (_, vehicle, updateRequest0) <- createUpdateSpecAction()
-      (_, updateRequest1) <- createUpdateSpecFor(vehicle, _.copy(installPos = 2))
+      (_, vehicle, updateSpec0) <- createUpdateSpecAction()
+      (_, updateSpec1) <- createUpdateSpecFor(vehicle, installPos = 2)
       result <- findPendingPackageIdsFor(vehicle.vin)
-    } yield (result, updateRequest0, updateRequest1)
+    } yield (result, updateSpec0, updateSpec1)
 
-    whenReady(db.run(dbIO)) { case (result, updateRequest0, updateRequest1)  =>
+    whenReady(db.run(dbIO)) { case (result, updateSpec0, updateSpec1)  =>
       result shouldNot be(empty)
       result should have(size(2))
 
       result match {
         case Seq(first, second) =>
-          first.id shouldBe updateRequest0.request.id
-          second.id shouldBe updateRequest1.request.id
+          first.id shouldBe updateSpec0.request.id
+          second.id shouldBe updateSpec1.request.id
         case _ =>
           fail("returned package list does not have expected elements")
       }


### PR DESCRIPTION
Depends on https://github.com/advancedtelematic/rvi_sota_server/pull/396

No change in the UI needed because the interface given by endpoints remains unchanged by this PR. Those endpoints are:
- PUT `api/v1/vehicle_updates/vin/order` , `VehicleUpdatesResource#setInstallOrder()`
- GET `api/v1/vehicle_updates` , `VehicleUpdatesResource#pendingPackages()`

