### PR TITLE
wait 10 seconds to start core and resolver docker images by overridin…

### DIFF
--- a/deploy/docker-compose/server-bare.yml
+++ b/deploy/docker-compose/server-bare.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_USER: "sota"
       MYSQL_PASSWORD: "s0ta"
       MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_core sota_core_test"
-
+    
   resolver:
     image: advancedtelematic/sota-resolver
     ports:
@@ -25,6 +25,8 @@ services:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
       RESOLVER_DB_MIGRATE: 'true'      
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-resolver"
+
 
   core:
     image: advancedtelematic/sota-core
@@ -41,6 +43,8 @@ services:
       CORE_DB_MIGRATE: 'true'
       RESOLVER_API_URI: "http://resolver:8081"
       CORE_INTERACTION_PROTOCOL: 'none'
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-core"
+
 
   webserver:
     image: advancedtelematic/sota-webserver

--- a/deploy/docker-compose/server-rvi-client.yml
+++ b/deploy/docker-compose/server-rvi-client.yml
@@ -39,6 +39,7 @@ services:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
       RESOLVER_DB_MIGRATE: 'true'     
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-resolver"
 
   core:
     image: advancedtelematic/sota-core
@@ -56,6 +57,7 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi_server:8801"
       SOTA_SERVICES_URI: "http://core:8080/rvi"
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-core"
 
 
   webserver:

--- a/deploy/docker-compose/server-rvi.yml
+++ b/deploy/docker-compose/server-rvi.yml
@@ -39,6 +39,7 @@ services:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
       RESOLVER_DB_MIGRATE: 'true'     
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-resolver"
 
   core:
     image: advancedtelematic/sota-core
@@ -56,7 +57,7 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       RVI_URI: "http://rvi_server:8801"
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-
+    entrypoint: /bin/sh -c "sleep 10 && bin/sota-resolver"
 
   webserver:
     image: advancedtelematic/sota-webserver


### PR DESCRIPTION
…g ENTRYPOINT

This is a hack, but it's a fairly harmless one that works very well. We just wait 10 seconds to start the core and resolver services, so that MariaDB has a chance to start before the migrations start hitting it.