### PR TITLE
new docker-compose files for unified build process

### DIFF
--- a/deploy/docker-compose/server-bare.yml
+++ b/deploy/docker-compose/server-bare.yml
@@ -60,17 +60,3 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
-
-  device_registry:
-    image: advancedtelematic/sota-device_registry
-    ports:
-      - 8083:8083
-    expose:
-      - 8083
-    depends_on:
-      - mysql
-    environment:
-      HOST: 0.0.0.0
-      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
-
-

--- a/deploy/docker-compose/server-bare.yml
+++ b/deploy/docker-compose/server-bare.yml
@@ -24,7 +24,8 @@ services:
     environment:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
-      RESOLVER_DB_MIGRATE: 'true'      
+      RESOLVER_DB_MIGRATE: 'true'
+      DB_ALIVE_URL: "mysql:3306"
 
   core:
     image: advancedtelematic/sota-core
@@ -41,6 +42,7 @@ services:
       CORE_DB_MIGRATE: 'true'
       RESOLVER_API_URI: "http://resolver:8081"
       CORE_INTERACTION_PROTOCOL: 'none'
+      DB_ALIVE_URL: "mysql:3306"
 
   webserver:
     image: advancedtelematic/sota-webserver

--- a/deploy/docker-compose/server-bare.yml
+++ b/deploy/docker-compose/server-bare.yml
@@ -11,8 +11,9 @@ services:
       MYSQL_ROOT_PASSWORD: "sota-test"
       MYSQL_USER: "sota"
       MYSQL_PASSWORD: "s0ta"
-      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_core sota_core_test"
-
+      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_resolver% sota_core sota_core_test sota_core% sota_device_registry"
+    command: ["--character-set-server=utf8", "--collation-server=utf8_unicode_ci", "--max-connections=1000"]
+    
   resolver:
     image: advancedtelematic/sota-resolver
     ports:
@@ -41,6 +42,7 @@ services:
       CORE_DB_URL: "jdbc:mariadb://mysql:3306/sota_core"
       CORE_DB_MIGRATE: 'true'
       RESOLVER_API_URI: "http://resolver:8081"
+      DEVICE_REGISTRY_API_URI: "http://device_registry:8083"
       CORE_INTERACTION_PROTOCOL: 'none'
       DB_ALIVE_URL: "mysql:3306"
 
@@ -58,4 +60,17 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
+
+  device_registry:
+    image: advancedtelematic/sota-device_registry
+    ports:
+      - 8083:8083
+    expose:
+      - 8083
+    depends_on:
+      - mysql
+    environment:
+      HOST: 0.0.0.0
+      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
+
 

--- a/deploy/docker-compose/server-rvi-client.yml
+++ b/deploy/docker-compose/server-rvi-client.yml
@@ -64,18 +64,6 @@ services:
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
 
-  device_registry:
-    image: advancedtelematic/sota-device_registry
-    ports:
-      - 8083:8083
-    expose:
-      - 8083
-    depends_on:
-      - mysql
-    environment:
-      HOST: 0.0.0.0
-      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
-
   rvi_server:
     image: advancedtelematic/rvi
     ports:

--- a/deploy/docker-compose/server-rvi-client.yml
+++ b/deploy/docker-compose/server-rvi-client.yml
@@ -11,20 +11,9 @@ services:
       MYSQL_ROOT_PASSWORD: "sota-test"
       MYSQL_USER: "sota"
       MYSQL_PASSWORD: "s0ta"
-      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_core sota_core_test"
-
-
-  rvi_server:
-    image: advancedtelematic/rvi
-    ports:
-      - 8801:8801
-      - 8807:8807
-    depends_on:
-      - mysql
-    stdin_open: true
-    tty: true
-    command: server
-
+      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_resolver% sota_core sota_core_test sota_core% sota_device_registry"
+    command: ["--character-set-server=utf8", "--collation-server=utf8_unicode_ci", "--max-connections=1000"]
+    
   resolver:
     image: advancedtelematic/sota-resolver
     ports:
@@ -33,12 +22,11 @@ services:
       - 8081
     depends_on:
       - mysql
-      - rvi_server
-      - core
     environment:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
-      RESOLVER_DB_MIGRATE: 'true'     
+      RESOLVER_DB_MIGRATE: 'true'
+      DB_ALIVE_URL: "mysql:3306"
 
   core:
     image: advancedtelematic/sota-core
@@ -48,20 +36,22 @@ services:
       - 8080
     depends_on:
       - mysql
+      - resolver
       - rvi_server
     environment:
       HOST: 0.0.0.0
       CORE_DB_URL: "jdbc:mariadb://mysql:3306/sota_core"
       CORE_DB_MIGRATE: 'true'
       RESOLVER_API_URI: "http://resolver:8081"
+      DEVICE_REGISTRY_API_URI: "http://device_registry:8083"
+      CORE_INTERACTION_PROTOCOL: 'rvi'
+      DB_ALIVE_URL: "mysql:3306"
       RVI_URI: "http://rvi_server:8801"
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-
 
   webserver:
     image: advancedtelematic/sota-webserver
     depends_on:
-      - rvi_server
       - resolver
       - core
     ports:
@@ -73,6 +63,29 @@ services:
       RESOLVER_API_URI: "http://resolver:8081"
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
+
+  device_registry:
+    image: advancedtelematic/sota-device_registry
+    ports:
+      - 8083:8083
+    expose:
+      - 8083
+    depends_on:
+      - mysql
+    environment:
+      HOST: 0.0.0.0
+      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
+
+  rvi_server:
+    image: advancedtelematic/rvi
+    ports:
+      - 8801:8801
+      - 8807:8807
+    depends_on:
+      - mysql
+    stdin_open: true
+    tty: true
+    command: server
 
   rvi_client:
     image: advancedtelematic/rvi

--- a/deploy/docker-compose/server-rvi.yml
+++ b/deploy/docker-compose/server-rvi.yml
@@ -11,20 +11,9 @@ services:
       MYSQL_ROOT_PASSWORD: "sota-test"
       MYSQL_USER: "sota"
       MYSQL_PASSWORD: "s0ta"
-      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_core sota_core_test"
-
-
-  rvi_server:
-    image: advancedtelematic/rvi
-    ports:
-      - 8801:8801
-      - 8807:8807
-    depends_on:
-      - mysql
-    stdin_open: true
-    tty: true
-    command: server
-
+      MYSQL_DATABASES: "sota_resolver sota_resolver_test sota_resolver% sota_core sota_core_test sota_core% sota_device_registry"
+    command: ["--character-set-server=utf8", "--collation-server=utf8_unicode_ci", "--max-connections=1000"]
+    
   resolver:
     image: advancedtelematic/sota-resolver
     ports:
@@ -33,12 +22,11 @@ services:
       - 8081
     depends_on:
       - mysql
-      - rvi_server
-      - core
     environment:
       HOST: 0.0.0.0
       RESOLVER_DB_URL: "jdbc:mariadb://mysql:3306/sota_resolver"
-      RESOLVER_DB_MIGRATE: 'true'     
+      RESOLVER_DB_MIGRATE: 'true'
+      DB_ALIVE_URL: "mysql:3306"
 
   core:
     image: advancedtelematic/sota-core
@@ -48,20 +36,22 @@ services:
       - 8080
     depends_on:
       - mysql
+      - resolver
       - rvi_server
     environment:
       HOST: 0.0.0.0
       CORE_DB_URL: "jdbc:mariadb://mysql:3306/sota_core"
       CORE_DB_MIGRATE: 'true'
       RESOLVER_API_URI: "http://resolver:8081"
+      DEVICE_REGISTRY_API_URI: "http://device_registry:8083"
+      CORE_INTERACTION_PROTOCOL: 'rvi'
+      DB_ALIVE_URL: "mysql:3306"
       RVI_URI: "http://rvi_server:8801"
       SOTA_SERVICES_URI: "http://core:8080/rvi"
-
 
   webserver:
     image: advancedtelematic/sota-webserver
     depends_on:
-      - rvi_server
       - resolver
       - core
     ports:
@@ -74,3 +64,25 @@ services:
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
 
+  device_registry:
+    image: advancedtelematic/sota-device_registry
+    ports:
+      - 8083:8083
+    expose:
+      - 8083
+    depends_on:
+      - mysql
+    environment:
+      HOST: 0.0.0.0
+      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
+
+  rvi_server:
+    image: advancedtelematic/rvi
+    ports:
+      - 8801:8801
+      - 8807:8807
+    depends_on:
+      - mysql
+    stdin_open: true
+    tty: true
+    command: server

--- a/deploy/docker-compose/server-rvi.yml
+++ b/deploy/docker-compose/server-rvi.yml
@@ -64,18 +64,6 @@ services:
       PLAY_CRYPTO_SECRET: "YM5B6o<ywKn4tTyA;tOZ<2xUEajF4DDi=O/PPm1Q^w2LqtKISd9oqYT6b>>C1gQa"
       LDAP_INMEMORY_ENABLE: 'true'
 
-  device_registry:
-    image: advancedtelematic/sota-device_registry
-    ports:
-      - 8083:8083
-    expose:
-      - 8083
-    depends_on:
-      - mysql
-    environment:
-      HOST: 0.0.0.0
-      DEVICE_REGISTRY_DB_URL: "jdbc:mariadb://mysql:3306/sota_device_registry"
-
   rvi_server:
     image: advancedtelematic/rvi
     ports:

--- a/deploy/entrypoint-core.sh
+++ b/deploy/entrypoint-core.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "$DB_ALIVE_URL" ]; then
+	bin/sota-core $@
+else
+	./wait-for-it.sh $DB_ALIVE_URL -s -t 120 && bin/sota-core $@
+fi

--- a/deploy/entrypoint-resolver.sh
+++ b/deploy/entrypoint-resolver.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -z "$DB_ALIVE_URL" ]; then
+	bin/sota-core $@
+else
+	./wait-for-it.sh $DB_ALIVE_URL -s -t 120 && bin/sota-resolver $@
+fi

--- a/deploy/wait-for-it.sh
+++ b/deploy/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -6,7 +6,10 @@ import sbt._
 import sbt.Keys._
 import sbtbuildinfo._
 import sbtbuildinfo.BuildInfoKeys._
-import com.typesafe.sbt.packager.Keys.dockerExposedPorts
+import com.typesafe.sbt.packager.docker.DockerPlugin
+import DockerPlugin.autoImport.Docker
+import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.docker._
 import com.typesafe.sbt.web._
 
 
@@ -93,6 +96,9 @@ object SotaBuild extends Build {
       flywayUser := sys.env.get("RESOLVER_DB_USER").orElse( sys.props.get("resolver.db.user") ).getOrElse("sota"),
       flywayPassword := sys.env.get("RESOLVER_DB_PASSWORD").orElse( sys.props.get("resolver.db.password")).getOrElse("s0ta")
     ))
+    .settings(mappings in Docker += (file("deploy/wait-for-it.sh") -> "/opt/docker/wait-for-it.sh"))
+    .settings(mappings in Docker += (file("deploy/entrypoint-resolver.sh") -> "/opt/docker/entrypoint.sh"))
+    .settings(dockerEntrypoint := Seq("./entrypoint.sh"))
     .settings(inConfig(RandomTests)(Defaults.testTasks): _*)
     .settings(inConfig(UnitTests)(Defaults.testTasks): _*)
     .configs(RandomTests)
@@ -113,6 +119,9 @@ object SotaBuild extends Build {
       flywayUser := sys.env.get("CORE_DB_USER").orElse( sys.props.get("core.db.user") ).getOrElse("sota"),
       flywayPassword := sys.env.get("CORE_DB_PASSWORD").orElse( sys.props.get("core.db.password")).getOrElse("s0ta")
     ))
+    .settings(mappings in Docker += (file("deploy/wait-for-it.sh") -> "/opt/docker/wait-for-it.sh"))
+    .settings(mappings in Docker += (file("deploy/entrypoint-core.sh") -> "/opt/docker/entrypoint.sh"))
+    .settings(dockerEntrypoint := Seq("./entrypoint.sh"))
     .settings(inConfig(UnitTests)(Defaults.testTasks): _*)
     .settings(inConfig(IntegrationTests)(Defaults.testTasks): _*)
     .configs(IntegrationTests, UnitTests)


### PR DESCRIPTION
There is one big change in this PR that might break some things: the containers for core and resolver now won't start up until there is a database available, and need the database address set as an environment variable. The new docker-compose files and teamcity both take this into account, but if there are other projects around that spin up rvi_sota_server docker images, they need to know about the new variable.