### PR TITLE
PRO-562 Milliseconds for db

### DIFF
--- a/core/src/main/resources/db/migration/V12__upgrade_to_millisec.sql
+++ b/core/src/main/resources/db/migration/V12__upgrade_to_millisec.sql
@@ -1,0 +1,21 @@
+ALTER TABLE UpdateRequest
+MODIFY COLUMN creation_time DATETIME(3) NOT NULL,
+MODIFY COLUMN start_after   DATETIME(3) NOT NULL,
+MODIFY COLUMN finish_before DATETIME(3) NOT NULL
+;
+
+ALTER TABLE InstallHistory
+MODIFY COLUMN completionTime DATETIME(3)
+;
+
+ALTER TABLE Vehicle
+MODIFY COLUMN last_seen DATETIME(3) NULL
+;
+
+ALTER TABLE OperationResult
+MODIFY COLUMN received_at DATETIME(3) NOT NULL
+;
+
+ALTER TABLE UpdateSpec
+MODIFY COLUMN creation_time DATETIME(3) NOT NULL
+;

--- a/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/VehicleUpdatesSpec.scala
@@ -203,9 +203,9 @@ class VehicleUpdatesSpec extends FunSuite
     // insert update spec C install pos 0
     val dbIO = for {
       (_, vehicle, updateSpec0) <- createUpdateSpecAction();
-      instant1 = updateSpec0.creationTime.getMillis + 1000; // if created in quick succession duplicates creationTime
+      instant1 = updateSpec0.creationTime.getMillis + 1; // if created in quick succession duplicates creationTime
       (_, updateSpec1) <- createUpdateSpecFor(vehicle, installPos = 0, withMillis = instant1)
-      instant2 = updateSpec1.creationTime.getMillis + 1000; // if created in quick succession duplicates creationTime
+      instant2 = updateSpec1.creationTime.getMillis + 1; // if created in quick succession duplicates creationTime
       (_, updateSpec2) <- createUpdateSpecFor(vehicle, installPos = 0, withMillis = instant2)
       result <- findPendingPackageIdsFor(vehicle.vin)
     } yield (result, updateSpec0, updateSpec1, updateSpec2)

--- a/device-registry/src/main/resources/db/migration/V2__upgrade_to_millisec.sql
+++ b/device-registry/src/main/resources/db/migration/V2__upgrade_to_millisec.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Device
+MODIFY COLUMN last_seen DATETIME(3) NULL
+;


### PR DESCRIPTION
- requires 
  - MySQL 5.6.4 or higher, http://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html
  - or
  - MariaDB 5.3 or higher, https://mariadb.com/kb/en/mariadb/microseconds-in-mariadb/