### PR TITLE
PRO-563 remove dependency on nscala-time, use JodaTime instead

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -9,8 +9,9 @@ import java.util.UUID
 import org.genivi.sota.core.data.UpdateRequest
 import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.PackageId
-import org.joda.time.DateTime
 import slick.driver.MySQLDriver.api._
+import org.joda.time.DateTime
+import org.joda.time.Interval
 
 import scala.concurrent.ExecutionContext
 
@@ -45,16 +46,15 @@ object UpdateRequests {
     def description = column[String]("description")
     def requestConfirmation = column[Boolean]("request_confirmation")
 
-    import com.github.nscala_time.time.Imports._
     import shapeless._
 
     implicit val IntervalGen : Generic[Interval] = new Generic[Interval] {
       type Repr = DateTime :: DateTime :: HNil
 
-      override def to(x : Interval) : Repr = x.start :: x.end :: HNil
+      override def to(x : Interval) : Repr = x.getStart :: x.getEnd :: HNil
 
       override def from( repr : Repr) : Interval = repr match {
-        case start :: end :: HNil => start to end
+        case start :: end :: HNil => new Interval(start, end)
       }
     }
 
@@ -63,9 +63,9 @@ object UpdateRequests {
 
     def * = (id, namespace, packageName, packageVersion, creationTime, startAfter, finishBefore,
              priority, signature, description.?, requestConfirmation).shaped <>
-      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, x._6 to x._7, x._8, x._9, x._10, x._11),
+      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, new Interval(x._6, x._7), x._8, x._9, x._10, x._11),
       (x: UpdateRequest) => Some((x.id, x.namespace, x.packageId.name, x.packageId.version, x.creationTime,
-                                  x.periodOfValidity.start, x.periodOfValidity.end, x.priority,
+                                  x.periodOfValidity.getStart, x.periodOfValidity.getEnd, x.priority,
                                   x.signature, x.description, x.requestConfirmation)))
   }
   // scalastyle:on

--- a/core/src/main/scala/org/genivi/sota/core/resolver/Connectivity.scala
+++ b/core/src/main/scala/org/genivi/sota/core/resolver/Connectivity.scala
@@ -4,7 +4,7 @@
  */
 package org.genivi.sota.core.resolver
 
-import com.github.nscala_time.time.Imports.DateTime
+import org.joda.time.DateTime
 import io.circe.{Encoder, Json}
 
 import scala.concurrent.Future

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviClient.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviClient.scala
@@ -4,9 +4,9 @@
  */
 package org.genivi.sota.core.rvi
 
-import com.github.nscala_time.time.Imports.DateTime
 import io.circe._
 import org.genivi.sota.core.resolver.ConnectivityClient
+import org.joda.time.DateTime
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
@@ -24,7 +24,6 @@ class RviUpdateNotifier(services: ServerServices) extends UpdateNotifier {
 
   override def notifyVehicle(vin: Vehicle.Vin, update: UpdateSpec)
                             (implicit connectivity: Connectivity, ec: ExecutionContext): Future[Int] = {
-    import com.github.nscala_time.time.Imports._
     import io.circe.generic.auto._
 
     def toPackageUpdate( spec: UpdateSpec ) = {

--- a/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
@@ -27,7 +27,7 @@ import org.genivi.sota.core.resolver.ConnectivityClient
 import org.genivi.sota.core.storage.S3PackageStore
 import org.genivi.sota.core.transfer.VehicleUpdates
 import org.genivi.sota.data.Vehicle
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, Period}
 
 import scala.collection.immutable.Queue
 import scala.concurrent.duration.{Duration, FiniteDuration}
@@ -197,8 +197,7 @@ class TransferProtocolActor(db: Database,
   }
 
   def ttl() : DateTime = {
-    import com.github.nscala_time.time.Implicits._
-    DateTime.now + 5.minutes
+    DateTime.now.plus(Period.minutes(5))
   }
 
   /**
@@ -339,8 +338,7 @@ class PackageTransferActor(updateId: UUID,
   val buffer = ByteBuffer.allocate( chunkSize )
 
   def ttl() : DateTime = {
-    import com.github.nscala_time.time.Implicits._
-    DateTime.now + 5.minutes
+    DateTime.now.plus(Period.minutes(5))
   }
 
   def sendChunk(channel: FileChannel, index: Int) : Unit = {

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
@@ -38,7 +38,7 @@ class UpdateRequestResourceSpec extends FunSuite
   val resolver = new FakeExternalResolver()
 
   implicit val rviClient = new ConnectivityClient {
-    override def sendMessage[A](service: String, message: A, expirationDate: _root_.com.github.nscala_time.time.Imports.DateTime)(implicit encoder: Encoder[A]): Future[Int] = ???
+    override def sendMessage[A](service: String, message: A, expirationDate: DateTime)(implicit encoder: Encoder[A]): Future[Int] = ???
   }
 
   implicit val connectivity = DefaultConnectivity

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -20,7 +20,7 @@ import org.genivi.sota.core.resolver.DefaultExternalResolverClient
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.data.Namespace._
 import org.genivi.sota.data.{Namespaces, PackageId, Vehicle}
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, Period}
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures.{PatienceConfig, convertScalaFuture, whenReady}
 import org.scalatest.prop.PropertyChecks
@@ -72,8 +72,7 @@ object SotaClient {
 
   class ClientActor(rviClient: ConnectivityClient, clientServices: ClientServices) extends Actor with ActorLogging {
     def ttl() : DateTime = {
-      import com.github.nscala_time.time.Implicits._
-      DateTime.now + 5.minutes
+      DateTime.now.plus(Period.minutes(5))
     }
 
     def downloading( services: ServerServices ) : Receive = {
@@ -113,7 +112,6 @@ object SotaClient {
 
     import io.circe.generic.auto._
     import org.genivi.sota.marshalling.CirceInstances._
-    import com.github.nscala_time.time.Imports._
 
     // TODO: Handle start,chunk,finish messages
     def route(actorRef : ActorRef) = pathPrefix("sota" / "client") {

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -51,7 +51,7 @@ object SotaBuild extends Build {
 
 
   lazy val compilerSettings = Seq(
-    scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.6", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-language:higherKinds"),
+    scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.8", "-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-language:higherKinds"),
     javacOptions in compile ++= Seq("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation")
   )
 

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -64,13 +64,13 @@ object SotaBuild extends Build {
   // the sub-projects
   lazy val common = Project(id = "sota-common", base = file("common"))
     .settings(basicSettings ++ compilerSettings)
-    .settings( libraryDependencies ++= Dependencies.Rest :+ Dependencies.AkkaHttpCirceJson :+ Dependencies.NscalaTime :+ Dependencies.Refined :+ Dependencies.CommonsCodec)
+    .settings( libraryDependencies ++= Dependencies.Rest :+ Dependencies.AkkaHttpCirceJson :+ Dependencies.JodaTime :+ Dependencies.JodaConvert :+ Dependencies.Refined :+ Dependencies.CommonsCodec)
     .dependsOn(commonData)
     .settings(Publish.settings)
 
   lazy val commonData = Project(id = "sota-common-data", base = file("common-data"))
     .settings(basicSettings ++ compilerSettings)
-    .settings(libraryDependencies ++= Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.CommonsCodec :+ Dependencies.TypesafeConfig :+ Dependencies.NscalaTime)
+    .settings(libraryDependencies ++= Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.Refined :+ Dependencies.CommonsCodec :+ Dependencies.TypesafeConfig :+ Dependencies.JodaTime :+ Dependencies.JodaConvert)
     .settings(Publish.settings)
 
   lazy val commonTest = Project(id = "sota-common-test", base = file("common-test"))
@@ -110,7 +110,7 @@ object SotaBuild extends Build {
 
   lazy val core = Project(id = "sota-core", base = file("core"))
     .settings( commonSettings ++ Migrations.settings ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.NscalaTime :+ Dependencies.Scalaz :+ Dependencies.Flyway :+ Dependencies.AmazonS3,
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.JodaTime :+ Dependencies.JodaConvert :+ Dependencies.Scalaz :+ Dependencies.Flyway :+ Dependencies.AmazonS3,
       testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi", "-l", "IntegrationTest"),
       testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi", "-n", "IntegrationTest"),
       parallelExecution in Test := true,
@@ -255,7 +255,8 @@ object Dependencies {
 
   lazy val Slick = Database ++ Seq(Flyway)
 
-  lazy val NscalaTime = "com.github.nscala-time" %% "nscala-time" % "2.0.0"
+  lazy val JodaTime = "joda-time" % "joda-time" % "2.9.4"
+  lazy val JodaConvert = "org.joda" % "joda-convert" % "1.2"
 
   lazy val ParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
 


### PR DESCRIPTION
Ticket: https://advancedtelematic.atlassian.net/browse/PRO-563

A follow-up task ( PRO-591 ) will migrate from Joda-Time to its replacement, JSR-310 java.time