### PR TITLE
[PRO-766] fix collation for device registry

### DIFF
--- a/device-registry/src/main/resources/db/migration/V4__ci_collation.sql
+++ b/device-registry/src/main/resources/db/migration/V4__ci_collation.sql
@@ -1,0 +1,1 @@
+ALTER DATABASE COLLATE utf8_unicode_ci;


### PR DESCRIPTION
sets the collation for *new* tables to case insensitive utf8 (as in core
and resolver)

this does not affect existing tables, for which one has to manually
`alter table Device convert to collate utf8_unicode_ci;`

this change will also prohibit to create devices which are conflicting
with case insensitive device names and device ids (this is true for VINs)

however, pro-796 will lift the unique constraint on device names.