### PR TITLE
Use alpine to run sota

### DIFF
--- a/deploy/entrypoint-core.sh
+++ b/deploy/entrypoint-core.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ -z "$DB_ALIVE_URL" ]; then
-	exec bin/sota-core $@
-else
-	./wait-for-it.sh $DB_ALIVE_URL -s -t 120 && exec bin/sota-core $@
-fi

--- a/deploy/entrypoint-device-registry.sh
+++ b/deploy/entrypoint-device-registry.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ -z "$DB_ALIVE_URL" ]; then
-	exec bin/sota-device_registry $@
-else
-	./wait-for-it.sh $DB_ALIVE_URL -s -t 120 && exec bin/sota-device_registry $@
-fi

--- a/deploy/entrypoint-resolver.sh
+++ b/deploy/entrypoint-resolver.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ -z "$DB_ALIVE_URL" ]; then
-	exec bin/sota-resolver $@
-else
-	./wait-for-it.sh $DB_ALIVE_URL -s -t 120 && exec bin/sota-resolver $@
-fi

--- a/deploy/service_entrypoint.sh
+++ b/deploy/service_entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ "$#" -lt "1" ]]; then
+ echo "usage: $0 <service_name> [service args]"
+ exit 1
+fi
+
+SERVICE_NAME=$1
+
+shift
+
+if [ -z "$DB_ALIVE_URL" ]; then
+	exec bin/$SERVICE_NAME $@
+else
+	./wait-for-it.sh $DB_ALIVE_URL --strict --timeout=120 && exec bin/$SERVICE_NAME $@
+fi

--- a/project/Packaging.scala
+++ b/project/Packaging.scala
@@ -1,16 +1,30 @@
 object Packaging {
   import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
-  import com.typesafe.sbt.packager.docker.DockerPlugin
-  import com.typesafe.sbt.packager.Keys._
+  import sbt._
   import sbt.Keys._
+  import com.typesafe.sbt.packager.docker.DockerPlugin
   import DockerPlugin.autoImport.Docker
-  import com.typesafe.sbt.SbtGit.git
+  import com.typesafe.sbt.packager.Keys._
+  import com.typesafe.sbt.packager.docker._
 
   lazy val settings = Seq(
     dockerRepository in Docker := Some("advancedtelematic"),
     packageName in Docker := packageName.value,
-    dockerBaseImage := "advancedtelematic/java:openjdk-8-jre",
-    dockerUpdateLatest in Docker := true
+    dockerUpdateLatest in Docker := true,
+    mappings in Docker += (file("deploy/wait-for-it.sh") -> s"/opt/${moduleName.value}/wait-for-it.sh"),
+    mappings in Docker += (file(s"deploy/service_entrypoint.sh") -> s"/opt/${moduleName.value}/entrypoint.sh"),
+    defaultLinuxInstallLocation in Docker := s"/opt/${moduleName.value}",
+    dockerCommands := Seq(
+      Cmd("FROM", "alpine:3.3"),
+      Cmd("RUN", "apk upgrade --update && apk add --update openjdk8-jre bash coreutils"),
+      ExecCmd("RUN", "mkdir", "-p", s"/var/log/${moduleName.value}"),
+      Cmd("ADD", "opt /opt"),
+      Cmd("WORKDIR", s"/opt/${moduleName.value}"),
+      ExecCmd("ENTRYPOINT", s"/opt/${moduleName.value}/entrypoint.sh", moduleName.value),
+      Cmd("RUN", s"chown -R daemon:daemon /opt/${moduleName.value}"),
+      Cmd("RUN", s"chown -R daemon:daemon /var/log/${moduleName.value}"),
+      Cmd("USER", "daemon")
+    )
   )
 
   val plugins = Seq(DockerPlugin, JavaAppPackaging)

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -9,9 +9,7 @@ import sbtbuildinfo.BuildInfoKeys._
 import com.typesafe.sbt.packager.docker.DockerPlugin
 import DockerPlugin.autoImport.Docker
 import com.typesafe.sbt.packager.Keys._
-import com.typesafe.sbt.packager.docker._
 import com.typesafe.sbt.web._
-
 
 object SotaBuild extends Build {
 
@@ -119,16 +117,15 @@ object SotaBuild extends Build {
       flywayUser := sys.env.get("CORE_DB_USER").orElse( sys.props.get("core.db.user") ).getOrElse("sota"),
       flywayPassword := sys.env.get("CORE_DB_PASSWORD").orElse( sys.props.get("core.db.password")).getOrElse("s0ta")
     ))
-    .settings(mappings in Docker += (file("deploy/wait-for-it.sh") -> "/opt/docker/wait-for-it.sh"))
-    .settings(mappings in Docker += (file("deploy/entrypoint-core.sh") -> "/opt/docker/entrypoint.sh"))
-    .settings(dockerEntrypoint := Seq("./entrypoint.sh"))
     .settings(inConfig(UnitTests)(Defaults.testTasks): _*)
     .settings(inConfig(IntegrationTests)(Defaults.testTasks): _*)
     .configs(IntegrationTests, UnitTests)
     .dependsOn(common, commonData, commonTest % "test", commonDbTest % "test", commonClient, commonMessaging)
     .enablePlugins(Packaging.plugins: _*)
+    .settings(Packaging.settings)
     .enablePlugins(BuildInfoPlugin)
     .settings(Publish.settings)
+
 
   import play.sbt.Play.autoImport._
   lazy val webServer = Project(id = "sota-webserver", base = file("web-server"),


### PR DESCRIPTION
This reduces container size from 350MB to about 121MB.

Refactor entrypoint bash scripts to avoid duplication.

Explicitly use Dockerfile steps so it's easier to control our Dockerfile