### PR TITLE
[PRO-813] Support large file uploads

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -1,10 +1,15 @@
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "DEBUG"
+  // The followwing settings are needed to support last file uploads
+  http.server.parsing.max-content-length = 500MB
+  http.server.request-timeout = 15 minutes
+  http.server.idle-timeout = 15 minutes
   actor {
     debug {
       # enable DEBUG logging of actor lifecycle changes
       lifecycle = on
+      receive = on
     }
   }
 }

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -12,6 +12,7 @@
     <logger name="sota.core" level="info" />
     <logger name="org.genivi.sota" level="info" />
     <logger name="slick.backend.DatabaseComponent.action" level="info" />
+    <logger name="akka" level="info" />
 
     <root level="${rootLevel:-INFO}">
         <appender-ref ref="STDOUT" />

--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -4,14 +4,17 @@
  */
 package org.genivi.sota.core
 
+import akka.Done
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.common.StrictForm
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{FormData, StatusCode, StatusCodes}
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.DebuggingDirectives
+import akka.http.scaladsl.server.directives.{CompleteOrRecoverWithMagnet, DebuggingDirectives}
 import akka.http.scaladsl.server.{Directive1, Route}
 import akka.stream._
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.Regex
 import io.circe.generic.auto._
@@ -26,6 +29,8 @@ import org.genivi.sota.marshalling.RefinedMarshallingSupport._
 import org.genivi.sota.rest.ErrorRepresentation
 import org.genivi.sota.rest.Validation._
 import slick.driver.MySQLDriver.api.Database
+
+import scala.concurrent.Future
 
 object PackagesResource {
   /**
@@ -86,27 +91,42 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database,
     * </ul>
     */
   def updatePackage(ns: Namespace, pid: PackageId): Route = {
+    def storePackage(ns: Namespace, pid: PackageId,
+                     description: Option[String], vendor: Option[String],
+                     signature: Option[String],
+                     fileName: String, file: Source[ByteString, Any]): Future[StatusCode] = {
+      for {
+        _ <- resolver.putPackage(ns, pid, description, vendor)
+        (uri, size, digest) <- packageStorageOp(pid, fileName, file)
+        pkg <- db.run(Packages.create(Package(ns, pid, uri, size, digest, description, vendor, signature)))
+      } yield StatusCodes.NoContent
+    }
+
+    def handleErrors(throwable: Throwable): Route = throwable match {
+      case ExternalResolverRequestFailed(msg, cause) =>
+        log.error(cause, s"Unable to create/update package: $msg")
+        complete(StatusCodes.ServiceUnavailable -> ErrorRepresentation(ErrorCodes.ExternalResolverError, msg))
+      case e => failWith(e)
+    }
+
+    // FIXME: There is a bug in akka, so we need to drain the stream before
+    // returning the response
+    def drainStream(file: Source[ByteString, Any]): Future[Done] = {
+      file.runWith(Sink.ignore).recoverWith { case t =>
+        log.warning(s"Could not drain stream: ${t.getMessage}")
+        Future.successful(Done)
+      }
+    }
+
     // TODO: Fix form fields metadata causing error for large upload
     parameters('description.?, 'vendor.?, 'signature.?) { (description, vendor, signature) =>
-      formFields('file.as[StrictForm.FileData]) { fileData =>
-        completeOrRecoverWith(
-          for {
-            _ <- resolver.putPackage(ns, pid, description, vendor)
-            (uri, size, digest) <- packageStorageOp(pid, fileData)
-            _ <- db.run(Packages.create(
-              Package(ns, pid, uri, size, digest, description, vendor, signature)))
-          } yield StatusCodes.NoContent
-        ) {
-          case ExternalResolverRequestFailed(msg, cause) =>
-            log.error(cause, s"Unable to create/update package: $msg")
-            complete(
-              StatusCodes.ServiceUnavailable ->
-                ErrorRepresentation(ErrorCodes.ExternalResolverError, msg))
-          case e => failWith(e)
-        }
+      fileUpload("file") { case (fileInfo, file) =>
+        val storePkgF = storePackage(ns, pid, description, vendor, signature, fileInfo.fileName, file)
+        completeOrRecoverWith(storePkgF) { ex => onComplete(drainStream(file))(_ => handleErrors(ex)) }
       }
     }
   }
+
 
   /**
     * An ota client GET the devices waiting for the given [[Package]] to be installed.

--- a/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
@@ -13,7 +13,7 @@ import akka.event.Logging
 import akka.http.scaladsl.common.StrictForm
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.stream.scaladsl.{FileIO, Sink}
+import akka.stream.scaladsl.{FileIO, Sink, Source}
 import akka.util.ByteString
 import org.genivi.sota.core.DigestCalculator.DigestResult
 import org.genivi.sota.data.PackageId
@@ -30,7 +30,7 @@ class LocalPackageStore()(implicit val system: ActorSystem, val mat: ActorMateri
   val log = Logging.getLogger(system, this)
 
   protected def localFileSink(packageId: PackageId, filename: String,
-                              fileData: StrictForm.FileData): Sink[ByteString, Future[(Uri, PackageSize)]] = {
+                              fileData: Source[ByteString, Any]): Sink[ByteString, Future[(Uri, PackageSize)]] = {
     val path = storePath.resolve(filename)
     val uri = Uri(path.toUri.toString)
 
@@ -39,11 +39,11 @@ class LocalPackageStore()(implicit val system: ActorSystem, val mat: ActorMateri
       .mapMaterializedValue(_.map(result => (uri, result.count)))
   }
 
-  override def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)] = {
-    val fileName = packageFileName(packageId, fileData.filename)
-    val sink = localFileSink(packageId, fileName, fileData)
-    val dataStream = fileData.entity.dataBytes
-    writePackage(packageId, dataStream, sink)
+  override def store(packageId: PackageId,
+                     fileName: String, fileData: Source[ByteString, Any]): Future[(Uri, PackageSize, DigestResult)] = {
+    val fname = packageFileName(packageId, Option(fileName))
+    val sink = localFileSink(packageId, fname, fileData)
+    writePackage(packageId, fileData, sink)
   }
 
   def retrieve(packageId: PackageId, packageUri: Uri): Future[(Uri, UniversalEntity)] = {

--- a/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
@@ -18,13 +18,15 @@ import org.genivi.sota.core.storage.PackageStorage.PackageSize
 import org.genivi.sota.data.PackageId
 import org.genivi.sota.core.data.Package
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.directives.FileInfo
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 class PackageStorage()(implicit system: ActorSystem, mat: ActorMaterializer, config: Config) {
-  def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)] = {
-    storage.store(packageId, fileData)
+  def store(packageId: PackageId, fileName: String,
+            fileData: Source[ByteString, Any]): Future[(Uri, PackageSize, DigestResult)] = {
+    storage.store(packageId, fileName, fileData)
   }
 
   def retrieveResponse(packageModel: Package): Future[HttpResponse] = {
@@ -65,12 +67,12 @@ object PackageStorage {
   import cats.syntax.show._
   type PackageSize = Long
   type PackageRetrievalOp = Package => Future[HttpResponse]
-  type PackageStorageOp = (PackageId, StrictForm.FileData) => Future[(Uri, PackageSize, DigestResult)]
+  type PackageStorageOp = (PackageId, String, Source[ByteString, Any]) => Future[(Uri, PackageSize, DigestResult)]
 
   private val HASH_ALGORITHM = "SHA-1"
 
   protected[storage] def writePackage(packageId: PackageId,
-                                      fileData: Source[ByteString, NotUsed],
+                                      fileData: Source[ByteString, Any],
                                       sink: Sink[ByteString, Future[(Uri, PackageSize)]])
                   (implicit system: ActorSystem, mat: ActorMaterializer): Future[(Uri, PackageSize, DigestResult)] = {
     implicit val ec = system.dispatcher
@@ -104,7 +106,8 @@ object PackageStorage {
 }
 
 trait PackageStore {
-  def store(packageId: PackageId, fileData: StrictForm.FileData): Future[(Uri, PackageSize, DigestResult)]
+  def store(packageId: PackageId, fileName: String,
+            fileData: Source[ByteString, Any]): Future[(Uri, PackageSize, DigestResult)]
 
   def retrieve(packageId: PackageId, packageUri: Uri): Future[(Uri, UniversalEntity)]
 }

--- a/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
@@ -4,14 +4,14 @@
  */
 package org.genivi.sota.core.storage
 
-import java.io.{File, InputStream}
+import java.io.{File, FileInputStream, InputStream}
 
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.common.StrictForm.FileData
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.stream.scaladsl.{FileIO, Sink, StreamConverters}
+import akka.stream.scaladsl.{FileIO, Sink, Source, StreamConverters}
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.s3.AmazonS3Client
@@ -22,6 +22,8 @@ import org.genivi.sota.core.data.Package
 import org.genivi.sota.data.PackageId
 import java.time.{Duration, Instant}
 
+import akka.util.ByteString
+import com.amazonaws.services.s3.transfer.TransferManager
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -36,19 +38,36 @@ class S3PackageStore(credentials: S3Credentials)
 
   val bucketId = credentials.bucketId
 
+  val log = LoggerFactory.getLogger(this.getClass)
+
   lazy val s3client = {
     val client = new AmazonS3Client(credentials)
     client.setRegion(Region.getRegion(Regions.EU_CENTRAL_1))
     client
   }
 
-  override def store(packageId: PackageId, fileData: FileData): Future[(Uri, PackageSize, DigestResult)] = {
-    val filename = packageFileName(packageId, fileData.filename)
+  override def store(packageId: PackageId,
+                     fileName: String, fileData: Source[ByteString, Any]): Future[(Uri, PackageSize, DigestResult)] = {
+    val filename = packageFileName(packageId, Option(fileName))
 
-    val sink = StreamConverters.asInputStream()
-      .mapMaterializedValue { is => upload(is, filename, fileData) }
+    val tempFile = File.createTempFile(filename, ".tmp")
 
-    writePackage(packageId, fileData.entity.dataBytes, sink)
+    // The s3 sdk requires us to specify the file size if using a stream
+    // so we always need to cache the file into the filesystem before uploading
+    val sink = FileIO.toPath(tempFile.toPath)
+      .mapMaterializedValue {
+        _.flatMap { result =>
+          if(result.wasSuccessful) {
+            upload(tempFile, filename, fileData)
+              .andThen { case _ =>
+                Try(tempFile.delete())
+              }
+          } else
+            Future.failed(result.getError)
+        }
+      }
+
+    writePackage(packageId, fileData, sink)
   }
 
   protected def signedUri(packageId: PackageId, uri: Uri): Future[Uri] = {
@@ -58,12 +77,11 @@ class S3PackageStore(credentials: S3Credentials)
     f map (uri => Uri(uri.toURI.toString))
   }
 
-  protected def upload(is: InputStream, fileName: String, fileData: FileData): Future[(Uri, Long)] = {
-    val metadata = new ObjectMetadata()
-    metadata.setContentLength(fileData.entity.contentLength)
-
-    val request = new PutObjectRequest(bucketId, fileName, is, metadata)
+  protected def upload(file: File, fileName: String, fileData: Source[ByteString, Any]): Future[(Uri, Long)] = {
+    val request = new PutObjectRequest(bucketId, fileName, file)
       .withCannedAcl(CannedAccessControlList.AuthenticatedRead)
+
+    log.info(s"Uploading $fileName to amazon s3")
 
     val asyncPut = for {
       putResult <- Future { s3client.putObject(request) }
@@ -71,6 +89,7 @@ class S3PackageStore(credentials: S3Credentials)
     } yield (putResult, url)
 
     asyncPut map { case (putResult, url)  =>
+      log.info(s"$fileName uploaded to $url")
       (Uri(url.toString), putResult.getMetadata.getContentLength)
     }
   }

--- a/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
@@ -11,7 +11,7 @@ import akka.event.Logging
 import akka.http.scaladsl.common.StrictForm.FileData
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.stream.scaladsl.{FileIO, StreamConverters}
+import akka.stream.scaladsl.{FileIO, Sink, StreamConverters}
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.s3.AmazonS3Client
@@ -20,7 +20,8 @@ import com.typesafe.config.Config
 import org.genivi.sota.core.DigestCalculator.DigestResult
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.data.PackageId
-import java.time.{Instant, Duration}
+import java.time.{Duration, Instant}
+
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future

--- a/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
@@ -39,7 +39,7 @@ class LocalPackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec")
     val storage = new LocalPackageStore()
     val packageId = PackageIdGenerators.genPackageId.sample.get
 
-    val f = storage.store(packageId, fileData)
+    val f = storage.store(packageId, fileData.filename.get, fileData.entity.dataBytes)
 
     whenReady(f) { case (uri, byteSize, digest) =>
       uri.path.toString should endWith("filename.rpm")
@@ -55,7 +55,7 @@ class LocalPackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec")
     val packageId = PackageIdGenerators.genPackageId.sample.get
 
     val f = for {
-      (uri, _, _) <- storage.store(packageId, fileData)
+      (uri, _, _) <- storage.store(packageId, fileData.filename.get, fileData.entity.dataBytes)
       (_, entity) <- storage.retrieve(packageId, uri)
       contents <- entity.dataBytes.runFold(ByteString(""))(_ ++ _)
     } yield contents

--- a/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
@@ -49,7 +49,7 @@ class S3PackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))
   test("stores a file on s3 with correct credentials", IntegrationTest) {
     val packageId = PackageIdGenerators.genPackageId.sample.get
 
-    val f = s3.store(packageId, fileData)
+    val f = s3.store(packageId, fileData.filename.get, fileData.entity.dataBytes)
 
     whenReady(f) { case (uri, _, _) =>
       uri.toString should startWith("https://rvi-sota-test.s3.eu-central-1.amazonaws.com/")
@@ -66,7 +66,7 @@ class S3PackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))
     }
 
     val f = for {
-      (uri, _, _) <- s3.store(packageId, fileData)
+      (uri, _, _) <- s3.store(packageId, fileData.filename.get, fileData.entity.dataBytes)
       (s3Url, _) <- s3.retrieve(packageId, uri)
       downloadContents <- http(s3Url)
     } yield downloadContents
@@ -79,7 +79,7 @@ class S3PackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))
   test("retrieves a file to a temporary file", IntegrationTest) {
     val packageId = PackageIdGenerators.genPackageId.sample.get
     val f = for {
-      (uri, _, _) <- s3.store(packageId, fileData)
+      (uri, _, _) <- s3.store(packageId, fileData.filename.get, fileData.entity.dataBytes)
       file <- s3.retrieveFile(uri)
       localContents <- FileIO.fromPath(file.toPath).runFold(ByteString.empty)(_ ++ _)
     } yield (file, localContents)


### PR DESCRIPTION
For local storage, the file is copied directly to disk without being
staged in memory.

For s3 storage, amazon requires us to specify the size of the file being
uploaded, so we need to first store the file in disk before uploading,
so we can calculate it's size. The file is now stored in disk for the
upload, and deleted immediately after the upload is finished.

Increased max file size and idle time to support large uploads

Refactored Package resource

