### PR TITLE
Bump scala_nats version

### DIFF
--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -293,5 +293,5 @@ object Dependencies {
 
   lazy val Kinesis = "com.amazonaws" % "amazon-kinesis-client" % "1.6.4"
 
-  lazy val Nats = "com.github.tyagihas" % "scala_nats_2.10" % "0.1"
+  lazy val Nats = "com.github.tyagihas" % "scala_nats_2.11" % "0.2"
 }


### PR DESCRIPTION
 - PRO-814
 - This bumps the version of java_nats used, giving us better error
   messages on connection failure.
 - Also means scala_nats and rvi-sota-server are both using Scala
   compiler v2.11.