### PR TITLE
[PRO-963] Fix docs-building Dockerfile, instructions

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:2.2.3
+FROM ruby:2.2.5
 
-RUN gem install asciidoctor
-RUN gem install jekyll
-RUN gem install jekyll-asciidoc
-RUN gem install therubyracer
+ADD Gemfile /
 
-WORKDIR /data
+RUN bundle install
+VOLUME /site
+WORKDIR /site
+ENTRYPOINT ["jekyll"]
+CMD ["b"]
 
-ADD . /data

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'asciidoctor', '1.5.4'
+gem 'jekyll', '2.5.3'
+gem 'jekyll-asciidoc', '1.0.1'
+gem 'therubyracer'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,7 @@
 all: 
-	mkdir -p output
-	docker build -t sota_docs_site .
-	docker run -t -i -v $(PWD)/output:/data/output sota_docs_site jekyll build -d output
+	docker run -t -i -v $(PWD):/site advancedtelematic/jekyll-asciidoc
 
 clean:
-	rm -rf output
+	rm -rf _site/
 
 .PHONY: all clean

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,8 +3,8 @@ These are the source files for the static documentation site hosted on GitHub Pa
 To get set up to build the site:
 
 ```
-gem install jekyll
-gem install jekyll-asciidoc
+gem install jekyll -v 2.5.3
+gem install jekyll-asciidoc -v 1.0.1
 ```
 
 To see a local version of the site, run `jekyll serve`, then open a browser at <http://localhost:4000/rvi_sota_server/>.
@@ -13,4 +13,6 @@ To simply build the site without running the local server, run `jekyll build`; i
 
 To update the site on Github Pages, build the site with `jekyll build`, then copy the complete generated static site to the gh-pages branch, commit, and push.
 
-You can also just run `make` to build the site using docker. It will output the static site to `./output`.
+You can also build the site using Docker. `make` will build the site using a docker container and output it to `./_site/`.
+
+You can also run a mini server to view your changes from docker, with `docker run -it -p 4000:4000 -v $(pwd):/site advancedtelematic/jekyll-asciidoc serve`; the site will be available at <http://localhost:4000/rvi_sota_server/>.


### PR DESCRIPTION
After jekyll bumped its stable version to 3.x a bunch of stuff broke. This fixes the dockerfile used to build the docs site.