### PR TITLE
Improve message bus publishing

### DIFF
--- a/common-messaging/src/main/resources/application.conf
+++ b/common-messaging/src/main/resources/application.conf
@@ -15,8 +15,6 @@ messaging {
     password = ${?NATS_PASSWORD}
   }
   kinesis {
-    streamName = "coreStream"
-    streamName = ${?KINESIS_STREAM_NAME}
     appName = "ota-plus"
     appName = ${?KINESIS_APP_NAME}
     regionName = "eu-central-1"

--- a/common-messaging/src/main/scala/org/genivi/sota/messaging/MessageBusManager.scala
+++ b/common-messaging/src/main/scala/org/genivi/sota/messaging/MessageBusManager.scala
@@ -1,19 +1,32 @@
 package org.genivi.sota.messaging
 
-import java.time.Instant
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.event.Logging
 import cats.data.Xor
 import com.typesafe.config.ConfigException.Missing
 import com.typesafe.config.{Config, ConfigException}
-import org.genivi.sota.messaging.Messages.{DeviceCreatedMessage, DeviceSeenMessage}
+import org.genivi.sota.messaging.Messages.{DeviceCreatedMessage, DeviceSeenMessage, Message}
 import org.genivi.sota.messaging.kinesis.KinesisClient
 import org.genivi.sota.messaging.nats.NatsClient
 
+trait MessageBusPublisher[-T <: Message] {
+  def publish(msg: T)
+}
+
+object MessageBusPublisher {
+  def apply[T <: Message](fn: T => Unit) = new MessageBusPublisher[T] {
+    override def publish(msg: T): Unit = fn(msg)
+  }
+
+  def ignore[T <: Message] = new MessageBusPublisher[T] {
+    override def publish(msg: T): Unit = ()
+  }
+}
+
 object MessageBusManager {
 
+  // TODO: All these can be made more general
 
   def getSubscriber(system: ActorSystem, config: Config): ConfigException Xor Done = {
     val log = Logging.getLogger(system, this.getClass)
@@ -27,7 +40,7 @@ object MessageBusManager {
       case "test" =>
         log.info("Starting messaging mode: Test")
         Xor.Right(Done)
-      case _ => throw new Missing("Unknown messaging mode specified")
+      case _ => Xor.left(new Missing("Unknown messaging mode specified"))
     }
   }
 
@@ -43,30 +56,37 @@ object MessageBusManager {
       case "test" =>
         log.info("Starting messaging mode: Test")
         Xor.Right(Done)
-      case _ => throw new Missing("Unknown messaging mode specified")
+      case _ => Xor.left(new Missing("Unknown messaging mode specified"))
     }
   }
 
-  def getDeviceSeenPublisher(system: ActorSystem, config: Config): ConfigException Xor (DeviceSeenMessage => Unit) = {
+  def getDeviceSeenPublisher(system: ActorSystem,
+                             config: Config): ConfigException Xor MessageBusPublisher[DeviceSeenMessage] = {
     val log = Logging.getLogger(system, this.getClass)
-    config.getString("messaging.mode") match {
+
+    val fn = config.getString("messaging.mode") match {
       case "nats" =>
         log.info("Starting messaging mode: NATS")
-        NatsClient.getDeviceSeenPublisher(system, config)
+        NatsClient
+          .getDeviceSeenPublisher(system, config)
       case "kinesis" =>
         log.info("Starting messaging mode: Kinesis")
-        KinesisClient.getDeviceSeenPublisher(system, config)
+        KinesisClient
+          .getDeviceSeenPublisher(system, config)
       case "test" =>
         log.info("Starting messaging mode: Test")
         Xor.right((msg:DeviceSeenMessage) => system.eventStream.publish(msg))
-      case _ => throw new Missing("Unknown messaging mode specified")
+      case _ => Xor.left(new Missing("Unknown messaging mode specified"))
     }
+
+    fn map(MessageBusPublisher(_))
   }
 
   def getDeviceCreatedPublisher(system: ActorSystem, config: Config)
-      : ConfigException Xor (DeviceCreatedMessage => Unit) = {
+      : ConfigException Xor MessageBusPublisher[DeviceCreatedMessage] = {
     val log = Logging.getLogger(system, this.getClass)
-    config.getString("messaging.mode") match {
+
+    val fn = config.getString("messaging.mode") match {
       case "nats" =>
         log.info("Starting messaging mode: NATS")
         NatsClient.getDeviceCreatedPublisher(system, config)
@@ -76,7 +96,9 @@ object MessageBusManager {
       case "test" =>
         log.info("Starting messaging mode: Test")
         Xor.right((msg:DeviceCreatedMessage) => system.eventStream.publish(msg))
-      case _ => throw new Missing("Unknown messaging mode specified")
+      case _ => Xor.left(new Missing("Unknown messaging mode specified"))
     }
+
+    fn map(MessageBusPublisher(_))
   }
 }

--- a/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
@@ -20,6 +20,8 @@ import java.time.Instant
 
 import org.genivi.sota.http.{AuthDirectives, NamespaceDirectives}
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
+import org.genivi.sota.messaging.MessageBusPublisher
+import org.genivi.sota.messaging.Messages.DeviceSeenMessage
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -46,7 +48,7 @@ class DeviceUpdatesResourceSpec extends FunSuite
   implicit val connectivity = new FakeConnectivity()
 
   lazy val service = new DeviceUpdatesResource(db, fakeResolver, fakeDeviceRegistry, defaultNamespaceExtractor,
-    AuthDirectives.allowAll)
+    AuthDirectives.allowAll, MessageBusPublisher.ignore)
 
   val fakeResolver = new FakeExternalResolver()
 
@@ -158,7 +160,7 @@ class DeviceUpdatesResourceSpec extends FunSuite
 
   test("GET to download a file returns 3xx if the package URL is an s3 URI") {
     val service = new DeviceUpdatesResource(db, fakeResolver, fakeDeviceRegistry, defaultNamespaceExtractor,
-      AuthDirectives.allowAll) {
+      AuthDirectives.allowAll, MessageBusPublisher.ignore) {
       override lazy val packageRetrievalOp: (Package) => Future[HttpResponse] = {
         _ => Future.successful {
           HttpResponse(StatusCodes.Found, Location("https://some-fake-place") :: Nil)

--- a/device-registry/src/test/scala/org/genivi/sota/device_registry/ResourceSpec.scala
+++ b/device-registry/src/test/scala/org/genivi/sota/device_registry/ResourceSpec.scala
@@ -7,10 +7,13 @@ package org.genivi.sota.device_registry.test
 import akka.http.scaladsl.server.{Directive1, Directives, Route}
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.syntax.xor
 import eu.timepit.refined.api.Refined
 import org.genivi.sota.core.DatabaseSpec
 import org.genivi.sota.data.Namespace
 import org.genivi.sota.device_registry.Routing
+import org.genivi.sota.messaging.{MessageBusManager, MessageBusPublisher}
+import org.genivi.sota.messaging.Messages.DeviceCreatedMessage
 import org.scalatest.Matchers
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec, Suite, WordSpec}
@@ -25,6 +28,8 @@ trait ResourceSpec extends
     with DatabaseSpec
     with BeforeAndAfterAll { self: Suite =>
 
+  import cats.data.Xor
+
   implicit val _db = db
 
   implicit val routeTimeout: RouteTestTimeout =
@@ -34,8 +39,16 @@ trait ResourceSpec extends
 
   lazy val namespaceExtractor = Directives.provide(defaultNs)
 
+  lazy val messageBusPublish: MessageBusPublisher[DeviceCreatedMessage] =
+    MessageBusManager
+      .getDeviceCreatedPublisher(system, system.settings.config) match {
+      case Xor.Right(v) => v
+      case Xor.Left(err) => throw err
+    }
+
+
   // Route
-  lazy implicit val route: Route = new Routing(namespaceExtractor).route
+  lazy implicit val route: Route = new Routing(namespaceExtractor, messageBusPublish).route
 
 }
 


### PR DESCRIPTION
Use more general way to pass around publishers

Do not initialize a message publisher inside route classes, these
classes should be resusable and dependencies should be injected

Do not fail when message bus cannot be initialized, log error and ignore
messages.