### PR TITLE
[PRO-967] PUT to /info to update description

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -135,6 +135,13 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database,
     }
   }
 
+  case class PackageInfo(description: String)
+
+  def updatePackageInfo(ns: Namespace, pid: PackageId): Route = {
+    entity(as[PackageInfo]) { pi =>
+      complete(db.run(Packages.updateInfo(ns,pid,pi.description)))
+    }
+  }
 
   /**
     * An ota client GET the devices waiting for the given [[Package]] to be installed.
@@ -149,6 +156,11 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database,
         searchPackage(ns)
       } ~
       (namespaceExtractor & extractPackageId) { (ns, pid) =>
+        path("info") {
+          put {
+            updatePackageInfo(ns,pid)
+          }
+        } ~
         pathEnd {
           get {
             fetch(ns, pid)

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -72,7 +72,10 @@ class WebService(notifier: UpdateNotifier,
               get { packagesResource.fetch(ns, pid) } ~
                 put { packagesResource.updatePackage(ns, pid) }
             } ~
-              path("queued") { packagesResource.queuedDevices(ns, pid) }
+            path("info") {
+              put {packagesResource.updatePackageInfo(ns, pid)}
+            } ~
+            path("queued") { packagesResource.queuedDevices(ns, pid) }
           }
       }
     }

--- a/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
@@ -97,4 +97,15 @@ object Packages {
       (x.name.mappedTo[String] ++ x.version.mappedTo[String] inSet ids.map( id => id.name.get + id.version.get))
     ).result
   }
+
+  /**
+   * Update the description about a package from its name & version
+   * @param id The name/version of the package to update
+   * @param description the new description
+   */
+  def updateInfo(ns: Namespace, id : PackageId, description: String)
+                (implicit ec: ExecutionContext): DBIO[Unit] = {
+    packages.filter(p => p.namespace === ns && p.name === id.name && p.version === id.version)
+            .map(_.description).update(description).map(_ => ())
+  }
 }


### PR DESCRIPTION
For ticket PRO-967 a new endpoint is needed to update the description of a package.