### PR TITLE
Fix scope format

### DIFF
--- a/.scalafmt
+++ b/.scalafmt
@@ -1,0 +1,4 @@
+--style defaultWithAlign
+--maxColumn 120
+--binPackParentConstructors false
+--alignByArrowEnumeratorGenerator true

--- a/common/src/test/scala/org/genivi/sota/Generators.scala
+++ b/common/src/test/scala/org/genivi/sota/Generators.scala
@@ -16,7 +16,7 @@ import org.scalacheck.{Arbitrary, Gen}
 
 object Generators {
 
-  val HmacKeySize = 16
+  val HmacKeySize = 32
 
   val SecretKeyGen: Gen[SecretKey] = Gen.containerOfN[Array, Byte](HmacKeySize, arbitrary[Byte] )
       .map( bytes => new SecretKeySpec(bytes, "HmacSHA256") )

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -218,7 +218,7 @@ object Dependencies {
 
   val AWSVersion = "1.11.15"
 
-  val JsonWebSecurityVersion = "0.2.1"
+  val JsonWebSecurityVersion = "0.3.1"
 
   val AkkaHttp = "com.typesafe.akka" %% "akka-http-experimental" % AkkaVersion
 


### PR DESCRIPTION
Token scope is a space-delimited string
Resolves PRO-1237