### PR TITLE
[PRO-1249] Refactor MessageBusListenerActor out to common-message

### DIFF
--- a/common-messaging/src/main/scala/org/genivi/sota/messaging/daemon/MessageBusListenerActor.scala
+++ b/common-messaging/src/main/scala/org/genivi/sota/messaging/daemon/MessageBusListenerActor.scala
@@ -1,0 +1,70 @@
+package org.genivi.sota.messaging.daemon
+
+import akka.NotUsed
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, Source}
+import cats.data.Xor
+import com.typesafe.config.ConfigException
+import org.genivi.sota.messaging.MessageBus
+import org.genivi.sota.messaging.Messages.{Message, MessageLike}
+import org.genivi.sota.messaging.daemon.MessageBusListenerActor.Subscribe
+import scala.concurrent.duration._
+import scala.util.Try
+
+class MessageBusListenerActor[Msg <: Message](props: Props,
+                                              mlArg: MessageLike[Msg]) extends Actor with ActorLogging {
+
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = context.dispatcher
+  implicit val ml = mlArg
+
+  override def postRestart(reason: Throwable): Unit = trySubscribeDelayed()
+
+  private def subscribed(listener: ActorRef): Receive = {
+    context watch listener
+
+    {
+      case Terminated(_) =>
+        log.error("Source/Listener died, subscribing again")
+        trySubscribeDelayed()
+        context become idle
+    }
+  }
+
+
+  private def subscribe(): Unit = {
+    log.info(s"Subscribing to ${ml.streamName}")
+    subscribeFn() match {
+      case Xor.Right(source) =>
+        val ref = source.runWith(Sink.actorSubscriber(props))
+        context become subscribed(ref)
+      case Xor.Left(err) =>
+        throw err
+    }
+  }
+
+  private def idle: Receive = {
+    case Subscribe =>
+      Try(subscribe()).failed.foreach { ex =>
+        log.error(ex, "Could not subscribe, trying again")
+        trySubscribeDelayed()
+      }
+  }
+
+  override def receive: Receive = idle
+
+  private def trySubscribeDelayed(delay: FiniteDuration = 5.seconds): Unit = {
+    context.system.scheduler.scheduleOnce(delay, self, Subscribe)
+  }
+
+  protected def subscribeFn(): ConfigException Xor Source[Msg, NotUsed] =
+    MessageBus.subscribe[Msg](context.system, context.system.settings.config)
+}
+
+object MessageBusListenerActor {
+  case object Subscribe
+
+  def props[Msg <: Message](props: Props)(implicit ml: MessageLike[Msg]): Props
+    = Props(classOf[MessageBusListenerActor[Msg]],props,ml)
+}

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory
 
 import scala.util.Try
 import org.genivi.sota.http.LogDirectives._
-import org.genivi.sota.resolver.daemon.MessageBusListenerActor
-import org.genivi.sota.resolver.daemon.MessageBusListenerActor.Subscribe
+import org.genivi.sota.resolver.daemon.ResolverMessageBusListenerActor
+import org.genivi.sota.messaging.daemon.MessageBusListenerActor.Subscribe
 import slick.driver.MySQLDriver.api._
 
 
@@ -98,7 +98,7 @@ object Boot extends App with Directives with BootMigrations {
     }
 
 
-  val messageBusListener = system.actorOf(MessageBusListenerActor.props(db))
+  val messageBusListener = system.actorOf(ResolverMessageBusListenerActor.props(db))
   messageBusListener ! Subscribe
 
   val host = config.getString("server.host")


### PR DESCRIPTION
[PRO-1249] refactor out from resolver the MessageBusListenerActor and refactor it to be able to listen to any Message. I'm a bit unsure on the scala code in particular is it correct to do [Msg <: Message] and how do one give implicit  to actors? 