### PR TITLE
Refactor blacklist routes

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
@@ -45,22 +45,23 @@ class BlacklistResource(namespaceExtractor: Directive1[Namespace],
       complete(BlacklistedPackages.update(namespace, req.packageId, req.comment).map(_ => StatusCodes.OK))
     }
 
+  def getNamespaceBlacklist(namespace: Namespace): Route =
+    complete(BlacklistedPackages.findFor(namespace))
+
+  def getPackageBlacklist(namespace: Namespace, packageId: PackageId): Route =
+    complete(BlacklistedPackages.findFor(namespace))
+
   def deletePackageBlacklist(namespace: Namespace, packageId: PackageId): Route =
     complete(BlacklistedPackages.remove(namespace, packageId).map(_ => StatusCodes.OK))
 
-  def getNamespaceBlacklist(namespace: Namespace): Route = {
-    complete(BlacklistedPackages.findFor(namespace))
-  }
-
   val route: Route =
     (handleErrors & pathPrefix("blacklist") & namespaceExtractor) { ns =>
+      post { addPackageToBlacklist(ns) } ~
+      put { updatePackageBlacklist(ns) } ~
+      get { getNamespaceBlacklist(ns) } ~
       extractPackageId { pkgId =>
-        post { addPackageToBlacklist(ns) } ~
-        put { updatePackageBlacklist(ns) } ~
+        get { getPackageBlacklist(ns, pkgId) } ~
         delete { deletePackageBlacklist(ns, pkgId) }
-      } ~
-        get {
-          getNamespaceBlacklist(ns)
-        }
+      }
     }
 }

--- a/core/src/test/scala/org/genivi/sota/core/BlacklistResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/BlacklistResourceSpec.scala
@@ -29,6 +29,8 @@ class BlacklistResourceSpec extends FunSuite
 
   val serviceRoute = new BlacklistResource(defaultNamespaceExtractor, MessageBusPublisher.ignore).route
 
+  private val blacklistPath = "/blacklist"
+
   def blacklistUrl(pkg: PackageId): Uri =
     Uri.Empty.withPath(Path("/blacklist") / pkg.name.get / pkg.version.get)
 
@@ -36,11 +38,9 @@ class BlacklistResourceSpec extends FunSuite
     val pkg = PackageGen.sample.get
     db.run(Packages.create(pkg)).futureValue
 
-    val url = blacklistUrl(pkg.id)
-
     val blacklistReq = BlacklistedPackageRequest(pkg.id, Some("Some comment"))
 
-    Post(url, blacklistReq) ~> serviceRoute ~> check {
+    Post(blacklistPath, blacklistReq) ~> serviceRoute ~> check {
       status shouldBe StatusCodes.Created
     }
 
@@ -54,11 +54,9 @@ class BlacklistResourceSpec extends FunSuite
   test("cannot create blacklist for non existent package") {
     val pkg = PackageGen.sample.get
 
-    val url = blacklistUrl(pkg.id)
-
     val blacklistReq = BlacklistedPackageRequest(pkg.id, Some("Some comment"))
 
-    Post(url, blacklistReq) ~> serviceRoute ~> check {
+    Post(blacklistPath, blacklistReq) ~> serviceRoute ~> check {
       status shouldBe StatusCodes.NotFound
     }
   }
@@ -79,9 +77,8 @@ class BlacklistResourceSpec extends FunSuite
   test("packages blacklist can be updated") {
     val pkg = createBlacklist()
     val blacklistReq = BlacklistedPackageRequest(pkg, Some("Hi"))
-    val url = blacklistUrl(pkg)
 
-    Put(url, blacklistReq) ~> serviceRoute ~> check {
+    Put(blacklistPath, blacklistReq) ~> serviceRoute ~> check {
       status shouldBe StatusCodes.OK
 
       Get("/blacklist") ~> serviceRoute ~> check {
@@ -96,11 +93,9 @@ class BlacklistResourceSpec extends FunSuite
     val pkg = PackageGen.sample.get
     db.run(Packages.create(pkg)).futureValue
 
-    val url = blacklistUrl(pkg.id)
-
     val blacklistReq = BlacklistedPackageRequest(pkg.id, Some("Some comment"))
 
-    Put(url, blacklistReq.copy(comment = Some("Hi"))) ~> serviceRoute ~> check {
+    Put(blacklistPath, blacklistReq.copy(comment = Some("Hi"))) ~> serviceRoute ~> check {
       status shouldBe StatusCodes.NotFound
     }
   }
@@ -129,7 +124,7 @@ class BlacklistResourceSpec extends FunSuite
 
     val blacklistReq = BlacklistedPackageRequest(pkg, Some("Some comment"))
 
-    Post(url, blacklistReq) ~> serviceRoute ~> check {
+    Post(blacklistPath, blacklistReq) ~> serviceRoute ~> check {
       status shouldBe StatusCodes.Created
     }
 

--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -414,25 +414,41 @@ paths:
           schema:
             type: array
             items:
-             $ref: '#/definitions/BlacklistItem'
-
-  "/blacklist/{package_name}/{package_version}":
+             $ref: '#/definitions/BlacklistedPackage'
     put:
+      consumes:
+        - application/json
       parameters:
-        - name: package_name
-          in: path
-          description: package name
+        - name: BlacklistedPackageRequest
+          in: body
+          description: An object describing the package to blacklist
           required: true
-          type: string
-        - name: package_version
-          in: path
-          description: package version
-          required: true
-          type: string
+          schema:
+            type: object
+            items:
+              $ref: '#definitions/BlacklistedPackageRequest'
       description: Update a blacklist item
+      responses:
+        200:
+          description: OK
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - name: BlacklistedPackageRequest
+          in: body
+          description: An object describing the package to blacklist
+          required: true
+          schema:
+            type: object
+            items:
+              $ref: '#definitions/BlacklistedPackageRequest'
       responses:
         201:
           description: Created
+      description: Create a blacklist item
+
+  "/blacklist/{package_name}/{package_version}":
     get:
       parameters:
         - name: package_name
@@ -449,7 +465,7 @@ paths:
       responses:
         200:
           description: OK
-    post:
+    delete:
       parameters:
         - name: package_name
           in: path
@@ -461,10 +477,10 @@ paths:
           description: package version
           required: true
           type: string
+      description: Delete a blacklist item
       responses:
-        201:
+        200:
           description: OK
-      description: Create a blacklist item
 
   "/impact/blacklist":
     get:
@@ -624,6 +640,22 @@ definitions:
         format: dateTime
         description: The time the update queue for the device was blocked.
   BlacklistItem:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/uuid'
+      namespace:
+        $ref: '#/definitions/namespace'
+      packageId:
+        $ref: '#/definitions/packageId'
+      comment:
+        type: string
+        description: A free text comment about the item
+      updatedAt:
+        type: string
+        format: dateTime
+        description: The last time this blacklist entry was changed.
+  BlacklistedPackageRequest:
     type: object
     properties:
       packageId:


### PR DESCRIPTION
 - PRO-1219
 - This removes the need to provide packageId twice; once in path, once
   in json request body.
 - Add some more detail to the docs and fix some ambiguity.
 - Add GET endpoint for a given blacklist package