### PR TITLE
Use a simple pk for Package

### DIFF
--- a/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
+++ b/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
@@ -1,6 +1,7 @@
 package org.genivi.sota.messaging
 
 import java.time.Instant
+import java.util.UUID
 
 import cats.data.Xor
 import io.circe.{Decoder, Encoder}
@@ -9,6 +10,7 @@ import io.circe.generic.semiauto._
 import org.genivi.sota.marshalling.CirceInstances._
 import org.genivi.sota.data.Device.{DeviceName, Id}
 import org.genivi.sota.data.{Device, Namespace, PackageId}
+
 import scala.reflect.ClassTag
 
 object Messages {
@@ -38,7 +40,7 @@ object Messages {
   //Create custom UpdateSpec here instead of using org.genivi.sota.core.data.UpdateSpec as that would require moving
   //multiple RVI messages into SotaCommon. Furthermore, for now this class contains just the info required by the
   //front end.
-  final case class UpdateSpec(namespace: Namespace, deviceId: Device.Id, packageId: PackageId,
+  final case class UpdateSpec(namespace: Namespace, deviceId: Device.Id, packageUuid: UUID,
                               status: String) extends Message
 
   implicit class StreamNameOp[T <: Class[_]](v: T) {

--- a/core/src/main/resources/db/migration/V19__add_package_uuid_columns.sql
+++ b/core/src/main/resources/db/migration/V19__add_package_uuid_columns.sql
@@ -1,0 +1,79 @@
+-- Package
+
+ALTER TABLE Package ADD uuid CHAR(36) ;
+
+UPDATE Package p, (SELECT uuid() uuid, name, version, namespace From Package) ids
+SET p.uuid = ids.uuid where p.name = ids.name and p.version = ids.version and p.namespace = ids.namespace
+;
+
+alter table Package add CONSTRAINT unique_namespace_name_version UNIQUE(namespace, name, version);
+
+alter table Package drop primary key, add primary key(uuid) ;
+
+ALTER TABLE Package CHANGE uuid uuid CHAR(36) NOT NULL ;
+
+-- install history
+
+ALTER TABLE InstallHistory ADD package_uuid CHAR(36) NOT NULL DEFAULT 0;
+
+update InstallHistory ih join Package p on
+p.name = ih.packageName and p.version = ih.packageVersion and ih.namespace = p.namespace
+set ih.package_uuid = p.uuid;
+
+ALTER TABLE InstallHistory CHANGE package_uuid package_uuid CHAR(36) NOT NULL;
+
+ALTER TABLE InstallHistory ADD CONSTRAINT fk_install_history_package_uuid
+FOREIGN KEY (package_uuid) REFERENCES Package(uuid);
+
+alter table InstallHistory drop foreign key install_history_package_id_fk ;
+
+alter table InstallHistory drop packageName, drop packageVersion, drop namespace;
+
+-- required package
+
+ALTER TABLE RequiredPackage ADD package_uuid CHAR(36) NOT NULL DEFAULT 0;
+
+update RequiredPackage rp join Package p on
+p.name = rp.package_name and p.version = rp.package_version and rp.namespace = p.namespace
+set rp.package_uuid = p.uuid;
+
+ALTER TABLE RequiredPackage CHANGE package_uuid package_uuid CHAR(36) NOT NULL;
+
+alter table RequiredPackage drop primary key, add primary key(package_uuid, update_request_id, device_uuid) ;
+
+ALTER TABLE RequiredPackage ADD CONSTRAINT fk_required_pkg_uuid
+FOREIGN KEY (package_uuid) REFERENCES Package(uuid);
+
+alter table RequiredPackage drop foreign key fk_downloads_package ;
+
+alter table RequiredPackage drop package_name, drop package_version, drop namespace;
+
+-- Update Request
+
+ALTER TABLE UpdateRequest ADD package_uuid CHAR(36) NOT NULL DEFAULT 0;
+
+update UpdateRequest ur join Package p on
+p.name = ur.package_name and p.version = ur.package_version and ur.namespace = p.namespace
+set ur.package_uuid = p.uuid;
+
+ALTER TABLE UpdateRequest CHANGE package_uuid package_uuid CHAR(36) NOT NULL;
+
+ALTER TABLE UpdateRequest ADD CONSTRAINT fk_update_request_pkg_uuid
+FOREIGN KEY (package_uuid) REFERENCES Package(uuid);
+
+alter table UpdateRequest drop foreign key  fk_update_request_package_id ;
+
+alter table UpdateRequest drop package_name, drop package_version, drop namespace ;
+
+-- BlacklistedPackage
+
+alter table BlacklistedPackage drop foreign key  BlacklistedPackage_pkg_fk ;
+
+-- update specs
+
+alter table UpdateSpec drop namespace ;
+
+-- Operation Result
+
+alter table OperationResult drop namespace ;
+

--- a/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
@@ -26,6 +26,8 @@ class BlacklistResource(namespaceExtractor: Directive1[Namespace],
 
   import akka.http.scaladsl.server.Directives._
   import PackagesResource.extractPackageId
+  import org.genivi.sota.core.data.client.ResponseConversions._
+  import org.genivi.sota.core.db.BlacklistedPackageResponse._
 
   implicit val _ec = system.dispatcher
 
@@ -46,10 +48,10 @@ class BlacklistResource(namespaceExtractor: Directive1[Namespace],
     }
 
   def getNamespaceBlacklist(namespace: Namespace): Route =
-    complete(BlacklistedPackages.findFor(namespace))
+    complete(BlacklistedPackages.findFor(namespace).map(_.toResponse))
 
   def getPackageBlacklist(namespace: Namespace, packageId: PackageId): Route =
-    complete(BlacklistedPackages.findFor(namespace))
+    complete(BlacklistedPackages.findFor(namespace).map(_.toResponse))
 
   def deletePackageBlacklist(namespace: Namespace, packageId: PackageId): Route =
     complete(BlacklistedPackages.remove(namespace, packageId).map(_ => StatusCodes.OK))

--- a/core/src/main/scala/org/genivi/sota/core/ImpactResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/ImpactResource.scala
@@ -21,7 +21,7 @@ class ImpactResource(namespaceExtractor: Directive1[Namespace])
   import system.dispatcher
 
   def runImpactAnalysis(namespace: Namespace): Route = {
-    val f = BlacklistedPackages.impact(namespace).map { _.map { case (k, v) ⇒ Map(k → v) } }
+    val f = BlacklistedPackages.impact(namespace).map { _.map { case (k, v) => Map(k → v) } }
     complete(f)
   }
 

--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -4,6 +4,8 @@
  */
 package org.genivi.sota.core
 
+import java.util.UUID
+
 import akka.Done
 import akka.actor.ActorSystem
 import akka.event.Logging
@@ -114,7 +116,8 @@ class PackagesResource(resolver: ExternalResolverClient, db : Database,
       val resultF = for {
         _ <- resolver.putPackage(ns, pid, description, vendor)
         (uri, size, digest) <- packageStorageOp(pid, ns.get, file)
-        pkg <- db.run(Packages.create(Package(ns, pid, uri, size, digest, description, vendor, signature)))
+        newPkg = Package(ns, UUID.randomUUID(), pid, uri, size, digest, description, vendor, signature)
+        pkg <- db.run(Packages.create(newPkg))
       } yield StatusCodes.NoContent
 
       resultF.pipeToBus(messageBusPublisher)(_ => PackageCreated(ns, pid, description, vendor, signature))

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -52,7 +52,7 @@ class WebService(notifier: UpdateNotifier,
   val packagesResource = new PackagesResource(resolver, db, messageBusPublisher, authNamespace)
   val updateService = new UpdateService(notifier, deviceRegistry)
   val updateRequestsResource = new UpdateRequestsResource(db, resolver, updateService, authNamespace)
-  val historyResource = new HistoryResource(db, authNamespace)
+  val historyResource = new HistoryResource(db)
   val blacklistResource = new BlacklistResource(authNamespace, messageBusPublisher)(db, system)
   val impactResource = new ImpactResource(authNamespace)(db, system)
 

--- a/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
@@ -6,8 +6,11 @@ package org.genivi.sota.core.data
 
 import org.genivi.sota.data.Namespace
 import java.time.Instant
-import org.genivi.sota.data.{PackageId, Device}
+
+import org.genivi.sota.data.{Device, PackageId}
 import java.util.UUID
+
+import org.genivi.sota.core.data.client.GenericResponseEncoder
 
 /**
  * Domain object for the update operation result
@@ -16,7 +19,6 @@ import java.util.UUID
  * @param resultCode The status of operation.
  * @param resultText The description of operation.
  * @param device The device of the vehicle the operation was performed on
- * @param namespace The namespace for the given row
  */
 case class OperationResult(
   id         : String,
@@ -24,14 +26,12 @@ case class OperationResult(
   resultCode : Int,
   resultText : String,
   device     : Device.Id,
-  namespace  : Namespace,
   receivedAt : Instant)
 
 object OperationResult {
   def from(rviOpResult: org.genivi.sota.core.rvi.OperationResult,
            updateRequestId: UUID,
-           device    : Device.Id,
-           namespace : Namespace
+           device    : Device.Id
           ): OperationResult = {
     OperationResult(
       UUID.randomUUID().toString,
@@ -39,28 +39,39 @@ object OperationResult {
       rviOpResult.result_code,
       rviOpResult.result_text,
       device    : Device.Id,
-      namespace : Namespace,
       Instant.now
     )
   }
 }
 
-/**
- * Domain object for the install history of a device
- * @param id The Id in the database. Initialize to Option.None
- * @param namespace The namespace for the given row
- * @param device The device that this install history belongs to
- * @param updateId The Id of the update
- * @param packageId Id of package which belongs to this update.
- * @param success The outcome of the install attempt
- * @param completionTime The date the install was attempted
- */
 case class InstallHistory(
   id             : Option[Long],
-  namespace      : Namespace,
+  device         : Device.Id,
+  updateId       : UUID,
+  packageUuid    : UUID,
+  success        : Boolean,
+  completionTime : Instant
+)
+
+case class ClientInstallHistory(
+  id             : Option[Long],
   device         : Device.Id,
   updateId       : UUID,
   packageId      : PackageId,
   success        : Boolean,
   completionTime : Instant
 )
+
+object ClientInstallHistory {
+  implicit val toResponseEncoder = GenericResponseEncoder {
+    (ih: InstallHistory, packageId: PackageId) =>
+      ClientInstallHistory(
+        ih.id,
+        ih.device,
+        ih.updateId,
+        packageId,
+        ih.success,
+        ih.completionTime
+      )
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/data/Package.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/Package.scala
@@ -4,6 +4,8 @@
  */
 package org.genivi.sota.core.data
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.Uri
 import io.circe.Json
 import org.genivi.sota.core.data.client.GenericResponseEncoder
@@ -27,6 +29,7 @@ import org.genivi.sota.marshalling.CirceInstances._
  */
 case class Package(
   namespace: Namespace,
+  uuid: UUID,
   id: PackageId,
   uri: Uri,
   size: Long,

--- a/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
@@ -19,7 +19,7 @@ import org.genivi.sota.core.db.InstallHistories.InstallHistoryTable
  * devices. It describes a single package, with a period of validity and priority
  * for the update.
  * @param id A generated unique ID for this update request
- * @param packageId The name and version of the package
+ * @param packageUUid The uuid the package
  * @param creationTime When this update request was entered into SOTA
  * @param periodOfValidity The start and end times when this update may be
  *                         installed. The install won't be attempted before
@@ -34,8 +34,7 @@ import org.genivi.sota.core.db.InstallHistories.InstallHistoryTable
  */
 case class UpdateRequest(
   id: UUID,
-  namespace: Namespace,
-  packageId: PackageId,
+  packageUuid: UUID,
   creationTime: Instant,
   periodOfValidity: Interval,
   priority: Int,
@@ -48,14 +47,14 @@ object UpdateRequest {
 
   import eu.timepit.refined.auto._
 
-  def default(namespace: Namespace, packageId: PackageId): UpdateRequest = {
+  def default(packageUuid: UUID): UpdateRequest = {
     val updateRequestId = UUID.randomUUID()
     val now = Instant.now
     val defaultPeriod = Duration.ofDays(1)
     val defaultInterval = Interval(now, now.plus(defaultPeriod))
     val defaultPriority = 10
 
-    UpdateRequest(updateRequestId, namespace, packageId,
+    UpdateRequest(updateRequestId, packageUuid,
       Instant.now, defaultInterval, defaultPriority, "", Some(""),
       requestConfirmation = false)
   }
@@ -100,11 +99,7 @@ case class UpdateSpec(
   dependencies: Set[Package],
   installPos: Int,
   creationTime: Instant,
-  updateTime: Instant
-) {
-
-  def namespace: Namespace = request.namespace
-
+  updateTime: Instant) {
   /**
    * The combined size (in bytes) of all the software updates in this package
    */

--- a/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
@@ -5,13 +5,14 @@
 package org.genivi.sota.core.db
 
 import org.genivi.sota.core.data.InstallHistory
-import org.genivi.sota.data.Namespace
-import org.genivi.sota.data.PackageId
 import org.genivi.sota.core.data.UpdateRequest
 import org.genivi.sota.core.data.UpdateSpec
 import java.time.Instant
+import java.util.UUID
+
+import org.genivi.sota.core.db.Packages.{LiftedPackageId, LiftedPackageShape}
 import slick.driver.MySQLDriver.api._
-import org.genivi.sota.data.{PackageId, Device}
+import org.genivi.sota.data.{Device, PackageId}
 import slick.driver.MySQLDriver.api._
 
 
@@ -35,21 +36,19 @@ object InstallHistories {
   class InstallHistoryTable(tag: Tag) extends Table[InstallHistory](tag, "InstallHistory") {
 
     def id             = column[Long]             ("id", O.AutoInc)
-    def namespace      = column[Namespace]        ("namespace")
     def device         = column[Device.Id]        ("device_uuid")
     def updateId       = column[java.util.UUID]   ("update_request_id")
-    def packageName    = column[PackageId.Name]   ("packageName")
-    def packageVersion = column[PackageId.Version]("packageVersion")
+    def packageUuid    = column[UUID]             ("package_uuid")
     def success        = column[Boolean]          ("success")
     def completionTime = column[Instant]          ("completionTime")
 
     // given `id` is already unique across namespaces, no need to include namespace. Also avoids Slick issue #966.
-    def pk = primaryKey("pk_InstallHistoryTable", (id))
+    def pk = primaryKey("pk_InstallHistoryTable", id)
 
-    def * = (id.?, namespace, device, updateId, packageName, packageVersion, success, completionTime).shaped <>
-      (r => InstallHistory(r._1, r._2, r._3, r._4, PackageId(r._5, r._6), r._7, r._8),
+    def * = (id.?, device, updateId, packageUuid, success, completionTime).shaped <>
+      (r => InstallHistory(r._1, r._2, r._3, r._4, r._5, r._6),
         (h: InstallHistory) =>
-          Some((h.id, h.namespace, h.device, h.updateId, h.packageId.name, h.packageId.version, h.success, h.completionTime)))
+          Some((h.id, h.device, h.updateId, h.packageUuid, h.success, h.completionTime)))
   }
   // scalastyle:on
 
@@ -65,21 +64,16 @@ object InstallHistories {
    * @param device The device to fetch data for
    * @return A list of the install history for that device
    */
-  def list(ns: Namespace, device: Device.Id): DBIO[Seq[InstallHistory]] =
-    installHistories.filter(i => i.namespace === ns && i.device === device).result
+  def list(device: Device.Id): DBIO[Seq[(InstallHistory, PackageId)]] =
+    installHistories
+      .filter(_.device === device)
+      .join(Packages.packages).on(_.packageUuid === _.uuid)
+      .map { case (ih, pkg) => (ih, LiftedPackageId(pkg.name, pkg.version)) }
+      .result
 
-  /**
-   * Add a row (with auto-inc PK) to [[InstallHistoryTable]]
-   * to persist the outcome of an [[UpdateSpec]] install attempt
-   * as reported by the SOTA client via RVI.
-   *
-   * @param device The device that the install attempt ran on
-   * @param updateId The Id of the [[UpdateRequest]] that was attempted to be installed
-   * @param success Whether the install was successful
-   */
-  def log(ns: Namespace, device: Device.Id, updateId: java.util.UUID,
-          packageId: PackageId, success: Boolean): DBIO[Int] = {
-    installHistories += InstallHistory(None, ns, device, updateId, packageId, success, Instant.now)
+  def log(device: Device.Id, updateId: java.util.UUID,
+          packageUUid: UUID, success: Boolean): DBIO[Int] = {
+    installHistories += InstallHistory(None, device, updateId, packageUUid, success, Instant.now)
   }
 
   /**
@@ -91,6 +85,6 @@ object InstallHistories {
     * @param success Whether the install was successful
     */
   def log(spec: UpdateSpec, success: Boolean): DBIO[Int] = {
-    log(spec.namespace, spec.device, spec.request.id, spec.request.packageId, success)
+    log(spec.device, spec.request.id, spec.request.packageUuid, success)
   }
 }

--- a/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
@@ -43,12 +43,11 @@ object OperationResults {
 
     import shapeless._
 
-    // given `id` is already unique across namespaces, no need to include namespace. Also avoids Slick issue #966.
-    def pk = primaryKey("pk_OperationResultTable", (id))
+    def pk = primaryKey("pk_OperationResultTable", id)
 
-    def * = (id, updateId, resultCode, resultText, device, namespace, receivedAt).shaped <>
-      (x => OperationResult(x._1, x._2, x._3, x._4, x._5, x._6, x._7),
-      (x: OperationResult) => Some((x.id, x.updateId, x.resultCode, x.resultText, x.device, x.namespace, x.receivedAt)))
+    def * = (id, updateId, resultCode, resultText, device, receivedAt).shaped <>
+      (x => OperationResult(x._1, x._2, x._3, x._4, x._5, x._6),
+      (x: OperationResult) => Some((x.id, x.updateId, x.resultCode, x.resultText, x.device, x.receivedAt)))
   }
   // scalastyle:on
 

--- a/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
@@ -4,6 +4,8 @@
  */
 package org.genivi.sota.core.db
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.Uri
 import org.genivi.sota.core.SotaCoreErrors
 import org.genivi.sota.core.data.Package
@@ -25,6 +27,12 @@ object Packages {
 
   import org.genivi.sota.refined.SlickRefined._
   import org.genivi.sota.db.Operators._
+  import org.genivi.sota.db.SlickExtensions._
+
+  case class LiftedPackageId(name: Rep[PackageId.Name], version: Rep[PackageId.Version])
+
+  implicit object LiftedPackageShape extends CaseClassShape(LiftedPackageId.tupled,
+    (p: (PackageId.Name, PackageId.Version)) => PackageId(p._1, p._2))
 
   /**
    * Slick mapping definition for the Package table
@@ -33,6 +41,7 @@ object Packages {
   // scalastyle:off
   class PackageTable(tag: Tag) extends Table[Package](tag, "Package") {
 
+    def uuid = column[UUID]("uuid")
     def namespace = column[Namespace]("namespace")
     def name = column[PackageId.Name]("name")
     def version = column[PackageId.Version]("version")
@@ -43,12 +52,13 @@ object Packages {
     def vendor = column[String]("vendor")
     def signature = column[String]("signature")
 
-    // insertOrUpdate buggy for composite-keys, see Slick issue #966.
-    def pk = primaryKey("pk_package", (namespace, name, version))
+    def pk = primaryKey("pk_package", uuid)
 
-    def * = (namespace, name, version, uri, size, checkSum, description.?, vendor.?, signature.?).shaped <>
-    (x => Package(x._1, PackageId(x._2, x._3), x._4, x._5, x._6, x._7, x._8, x._9),
-    (x: Package) => Some((x.namespace, x.id.name, x.id.version, x.uri, x.size, x.checkSum, x.description, x.vendor, x.signature)))
+    def uniqueUuid = index("Package_unique_name_version", (namespace, name, version), unique = true)
+
+    def * = (namespace, name, version, uri, size, checkSum, description.?, vendor.?, signature.?, uuid).shaped <>
+      (x => Package(x._1, x._10, PackageId(x._2, x._3), x._4, x._5, x._6, x._7, x._8, x._9),
+        (x: Package) => Some((x.namespace, x.id.name, x.id.version, x.uri, x.size, x.checkSum, x.description, x.vendor, x.signature, x.uuid)))
   }
   // scalastyle:on
 
@@ -76,14 +86,10 @@ object Packages {
     packages
       .filter(_.namespace === ns)
       .regexFilter(reg)(_.name, _.version)
-      .joinLeft(BlacklistedPackages.active).on { case (p, b) =>
-      p.name === b.pkgName && p.version === b.pkgVersion &&
-        p.namespace === b.namespace }
-      .map { case (pkg, blacklistO) =>
-        (pkg, blacklistO.map(_.active).getOrElse(false))
-      }
+      .joinLeft(BlacklistedPackages.active)
+      .on { case (pkg, bl) => pkg.name === bl.pkgName && pkg.version === bl.pkgVersion }
+      .map { case (pkg, blacklistO) =>  (pkg, blacklistO.map(_.active).getOrElse(false)) }
       .result
-
 
   def byId(ns: Namespace, id : PackageId)(implicit ec: ExecutionContext): DBIO[Package] =
     packages
@@ -102,6 +108,9 @@ object Packages {
       (x.name.mappedTo[String] ++ x.version.mappedTo[String] inSet ids.map( id => id.name.get + id.version.get))
     ).result
   }
+
+  def byUuid(uuid: UUID)(implicit ec: ExecutionContext): DBIO[Package] =
+    packages.filter(_.uuid === uuid).result.failIfNotSingle(SotaCoreErrors.MissingPackage)
 
   /**
    * Update the description about a package from its name & version

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -36,9 +36,7 @@ object UpdateRequests {
    */
   class UpdateRequestTable(tag: Tag) extends Table[UpdateRequest](tag, "UpdateRequest") {
     def id = column[UUID]("update_request_id")
-    def namespace = column[Namespace]("namespace")
-    def packageName = column[PackageId.Name]("package_name")
-    def packageVersion = column[PackageId.Version]("package_version")
+    def packageUuid = column[UUID]("package_uuid")
     def creationTime = column[Instant]("creation_time")
     def startAfter = column[Instant]("start_after")
     def finishBefore = column[Instant]("finish_before")
@@ -60,12 +58,12 @@ object UpdateRequests {
     }
 
     // given `id` is already unique across namespaces, no need to include namespace. Also avoids Slick issue #966.
-    def pk = primaryKey("pk_UpdateRequest", (id))
+    def pk = primaryKey("pk_UpdateRequest", id)
 
-    def * = (id, namespace, packageName, packageVersion, creationTime, startAfter, finishBefore,
+    def * = (id, packageUuid, creationTime, startAfter, finishBefore,
              priority, signature, description.?, requestConfirmation).shaped <>
-      (x => UpdateRequest(x._1, x._2, PackageId(x._3, x._4), x._5, Interval(x._6, x._7), x._8, x._9, x._10, x._11),
-      (x: UpdateRequest) => Some((x.id, x.namespace, x.packageId.name, x.packageId.version, x.creationTime,
+      (x => UpdateRequest(x._1, x._2, x._3, Interval(x._4, x._5), x._6, x._7, x._8, x._9),
+      (x: UpdateRequest) => Some((x.id, x.packageUuid, x.creationTime,
                                   x.periodOfValidity.start, x.periodOfValidity.end, x.priority,
                                   x.signature, x.description, x.requestConfirmation)))
   }

--- a/core/src/main/scala/org/genivi/sota/core/transfer/DeviceUpdates.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/DeviceUpdates.scala
@@ -21,10 +21,14 @@ import org.genivi.sota.core.rvi.UpdateReport
 import org.genivi.sota.data.{Device, Namespace, PackageId}
 import org.genivi.sota.db.Operators._
 import org.genivi.sota.db.SlickExtensions
+import org.genivi.sota.http.Errors
 import org.genivi.sota.http.Errors.MissingEntity
 import org.genivi.sota.messaging.{MessageBusPublisher, Messages}
 import slick.dbio.DBIO
 import slick.driver.MySQLDriver.api._
+import Packages.{LiftedPackageId, LiftedPackageShape}
+import org.genivi.sota.core.db.UpdateRequests.UpdateRequestTable
+import shapeless.{HList, ::, HNil}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -33,6 +37,8 @@ import scala.util.control.NoStackTrace
 object DeviceUpdates {
   import SlickExtensions._
   import org.genivi.sota.marshalling.CirceInstances._
+  import org.genivi.sota.db.Operators._
+  import org.genivi.sota.refined.SlickRefined._
 
   case class SetOrderFailed(msg: String) extends Exception(msg) with NoStackTrace
 
@@ -69,20 +75,19 @@ object DeviceUpdates {
                    (implicit ec: ExecutionContext, db: Database): Future[UpdateSpec] = {
 
     // add a row (with fresh UUID) to OperationResult table for each result of this report
-    val writeResultsIO = (ns: Namespace) => for {
+    val writeResultsIO = for {
       rviOpResult <- updateReport.operation_results
       dbOpResult   = OperationResult.from(
         rviOpResult,
         updateReport.update_id,
-        device,
-        ns)
+        device)
     } yield OperationResults.persist(dbOpResult)
 
     // look up the UpdateSpec to rewrite its status and to use it as FK in InstallHistory
     val newStatus = if (updateReport.isSuccess) UpdateStatus.Finished else UpdateStatus.Failed
     val dbIO = for {
       spec <- findUpdateSpecFor(device, updateReport.update_id)
-      _    <- DBIO.sequence(writeResultsIO(spec.namespace))
+      _    <- DBIO.sequence(writeResultsIO)
       _    <- UpdateSpecs.setStatus(spec, newStatus)
       _    <- InstallHistories.log(spec, updateReport.isSuccess)
       _    <- if (updateReport.isFail) {
@@ -90,37 +95,54 @@ object DeviceUpdates {
               } else {
                 DBIO.successful(true)
               }
-    } yield spec.copy(status = newStatus)
+      pkg <- findUpdateRequestPackage(updateReport.update_id)
+    } yield (spec.copy(status = newStatus), pkg.namespace)
 
     db.run(dbIO.transactionally).andThen {
-      case scala.util.Success(spec) =>
-        messageBus.publish(Messages.UpdateSpec(spec.namespace, device, spec.request.packageId,
+      case scala.util.Success((spec, namespace)) =>
+        messageBus.publish(Messages.UpdateSpec(namespace, device, spec.request.packageUuid,
         spec.status.toString))
-    }
+    }.map(_._1)
   }
+
+  private def findUpdateRequestPackage(updateRequestId: UUID)(implicit ec: ExecutionContext): DBIO[Package] = {
+    UpdateRequests
+      .byId(updateRequestId)
+      .failIfNone(Errors.MissingEntity(classOf[UpdateRequest]))
+      .flatMap(ur => Packages.byUuid(ur.packageUuid))
+  }
+
 
   def findPendingPackageIdsFor(device: Device.Id, includeInFlight: Boolean = true)
                               (implicit db: Database,
-                               ec: ExecutionContext): DBIO[Seq[(UpdateRequest, UpdateStatus, Instant)]] = {
+                               ec: ExecutionContext)
+  : DBIO[Seq[(UpdateRequest, UpdateStatus :: PackageId :: Instant :: HNil)]] = {
     val statusToInclude =
       if(includeInFlight)
         List(UpdateStatus.InFlight, UpdateStatus.Pending)
       else
         List(UpdateStatus.Pending)
 
-    updateSpecs
+    val updateSpecsQ =
+      updateSpecs
       .filter(_.device === device)
       .filter(_.status.inSet(statusToInclude))
-      .join(updateRequests).on(_.requestId === _.id)
-      .sortBy { case (sp, _) => (sp.installPos.asc, sp.creationTime.asc) }
-      .map(r => (r._2, r._1.status, r._1.updateTime))
+
+    val updateRequestStatusQ = for {
+        us <- updateSpecsQ
+        ur <- updateRequests if ur.id === us.requestId
+        pkg <- Packages.packages if ur.packageUuid === pkg.uuid
+      } yield (pkg.namespace, ur, us, LiftedPackageId(pkg.name, pkg.version))
+
+    val updateReqStatusPkgIdIO = updateRequestStatusQ
+      .sortBy { case (ns, ur, us, pid) => (us.installPos.asc, us.creationTime.asc) }
       .result
-      .flatMap {
-        BlacklistedPackages.filterBlacklisted[(UpdateRequest, UpdateStatus, Instant)] {
-          case (ur, _, _) => (ur.namespace, ur.packageId)
-        }
-      }
-      .map { _.zipWithIndex.map { case ((ur, us, updateAt), idx) => (ur.copy(installPos = idx), us, updateAt) } }
+
+    updateReqStatusPkgIdIO.flatMap {
+      BlacklistedPackages.filterBlacklisted(p => (p._1, p._4))
+    }.map { _.zipWithIndex.map {
+      case ((ns, ur, us, pid), idx) => (ur.copy(installPos = idx), us.status :: pid :: us.updatedAt :: HNil) }
+    }
   }
 
 
@@ -142,14 +164,11 @@ object DeviceUpdates {
 
     val specsWithDepsIO = updateSpecsIO flatMap { specsWithDeps =>
       val dBIOActions = specsWithDeps map { case ((updateSpec, updateReq), requiredPO) =>
-        val (_, _, deviceId, status, installPos, creationTime, updateTime) = updateSpec
-        (UpdateSpec(updateReq, deviceId, status, Set.empty, installPos, creationTime, updateTime), requiredPO)
+        (updateSpec.toUpdateSpec(updateReq, Set.empty), requiredPO)
       } map { case (spec, requiredPO) =>
         val depsIO = requiredPO map {
-          case (namespace, _, _, packageName, packageVersion) =>
-            Packages
-              .byId(namespace, PackageId(packageName, packageVersion))
-              .map(Some(_))
+          case (_, _, packageUuid) =>
+            Packages.byUuid(packageUuid).map(Some(_))
         } getOrElse DBIO.successful(None)
 
         depsIO map { p => spec.copy(dependencies = p.toSet) }

--- a/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
@@ -58,10 +58,7 @@ class PackageDownloadProcess(db: Database, packageRetrieval: PackageRetrievalOp)
                              (implicit ec: ExecutionContext): DBIO[Package] = {
     updateRequests
       .filter(_.id === updateRequestId)
-      .join(Packages.packages)
-      .on((updateRequest, packageM) =>
-        packageM.name === updateRequest.packageName && packageM.version === updateRequest.packageVersion &&
-          packageM.namespace === updateRequest.namespace)
+      .join(Packages.packages).on(_.packageUuid === _.uuid)
       .map { case (_, packageM) => packageM }
       .result
       .failIfNotSingle(SotaCoreErrors.MissingPackage)

--- a/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
@@ -4,6 +4,8 @@
  */
 package org.genivi.sota.core
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Path
@@ -55,10 +57,13 @@ class PackageResourceWordSpec extends WordSpec
   lazy val service = new PackagesResource(externalResolverClient, db, messageBusPublisher, defaultNamespaceExtractor)
 
   val testPackagesParams = List(
-    ("default", "vim", "7.0.1"), ("default", "vim", "7.1.1"),
-    ("default", "go", "1.4.0"), ("default", "go", "1.5.0"), ("default", "scala", "2.11.0"))
+    ("default", "vim", "7.0.1", UUID.randomUUID()),
+    ("default", "vim", "7.1.1", UUID.randomUUID()),
+    ("default", "go", "1.4.0", UUID.randomUUID()),
+    ("default", "go", "1.5.0", UUID.randomUUID()),
+    ("default", "scala", "2.11.0", UUID.randomUUID()))
   val testPackages:List[DataPackage] = testPackagesParams.map { pkg =>
-    DataPackage(Namespace(pkg._1), PackageId(Refined.unsafeApply(pkg._2), Refined.unsafeApply(pkg._3)),
+    DataPackage(Namespace(pkg._1), pkg._4, PackageId(Refined.unsafeApply(pkg._2), Refined.unsafeApply(pkg._3)),
                 Uri("www.example.com"), 123, "123", None, None, None)
   }
 

--- a/core/src/test/scala/org/genivi/sota/core/PackagesReader.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackagesReader.scala
@@ -1,5 +1,7 @@
 package org.genivi.sota.core
 
+import java.util.UUID
+
 import akka.http.scaladsl.model.Uri
 import eu.timepit.refined.refineV
 import eu.timepit.refined.api.Refined
@@ -23,7 +25,7 @@ object PackagesReader {
       version     <- readVersion( src.get( "Version" ) )
       size        <- src.get("Size").map( _.toLong )
       checkSum    <- src.get("SHA1")
-    } yield Package(Namespace("default"),
+    } yield Package(Namespace("default"), UUID.randomUUID(),
                     PackageId(Refined.unsafeApply(name), version),
                     size = size, description = src.get("Description"),
                     checkSum = checkSum, uri = Uri.Empty, vendor = src.get( "Maintainer" ), signature = Some("Signature") )

--- a/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateServiceSpec.scala
@@ -57,15 +57,15 @@ class UpdateServiceSpec extends PropSpec
 
   import org.genivi.sota.core.data.UpdateRequest
 
-  val AvailablePackageIdGen = Gen.oneOf(packages).map( _.id )
+  val availablePackageIdGen = Gen.oneOf(packages).map(_.uuid)
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
 
   implicit override val generatorDrivenConfig = PropertyCheckConfig(minSuccessful = 20)
 
   property("decline if package not found") {
-    forAll(updateRequestGen(defaultNs, PackageIdGen)) { (request: UpdateRequest) =>
-      whenReady( service.queueUpdate( request, _ => FastFuture.successful( Map.empty ) ).failed ) { e =>
+    forAll(updateRequestGen(Gen.uuid)) { (request: UpdateRequest) =>
+      whenReady( service.queueUpdate(defaultNs, request, _ => FastFuture.successful( Map.empty ) ).failed ) { e =>
         e shouldBe SotaCoreErrors.MissingPackage
       }
     }
@@ -87,18 +87,18 @@ class UpdateServiceSpec extends PropSpec
       vinsToDeps        <- Gen.listOfN(m, vinDepGen(missingPackages)).map( _.toMap )
     } yield (missingPackages, (_: Package) => FastFuture.successful(vinsToDeps))
 
-    forAll(updateRequestGen(defaultNs, AvailablePackageIdGen), resolverGen) { (request, resolverConf) =>
+    forAll(updateRequestGen(availablePackageIdGen), resolverGen) { (request, resolverConf) =>
       val (missingPackages, resolver) = resolverConf
-      whenReady(service.queueUpdate(request, resolver).failed.mapTo[PackagesNotFound]) { failure =>
+      whenReady(service.queueUpdate(defaultNs, request, resolver).failed.mapTo[PackagesNotFound]) { failure =>
         failure.packageIds.toSet.union(missingPackages.toSet) should contain theSameElementsAs missingPackages
       }
     }
   }
 
   property("upload spec per device") {
-    forAll(updateRequestGen(defaultNs, AvailablePackageIdGen), dependenciesGen(packages)) { (req, deps) =>
+    forAll(updateRequestGen(availablePackageIdGen), dependenciesGen(packages)) { (req, deps) =>
       val queueF = for {
-        specs <- service.queueUpdate(req, _ => Future.successful(deps))
+        specs <- service.queueUpdate(defaultNs, req, _ => Future.successful(deps))
         _ <- db.run(UpdateSpecs.listUpdatesById(Refined.unsafeApply(req.id.toString)))
       } yield specs
 
@@ -118,24 +118,24 @@ class UpdateServiceSpec extends PropSpec
 
     val f = for {
       (device, packageM) <- db.run(dbSetup)
-      updateRequest <- service.queueDeviceUpdate(device.namespace, device.id, packageM.id)
+      updateRequest <- service.queueDeviceUpdate(device.namespace, device.id, packageM.id).map(_._1)
       queuedPackages <- db.run(DeviceUpdates.findPendingPackageIdsFor(device.id))
     } yield (updateRequest, queuedPackages.map(_._1))
 
     whenReady(f) { case (updateRequest, queuedPackages) =>
-      updateRequest.packageId shouldBe newPackage.id
-      queuedPackages.map(_.packageId) should contain(newPackage.id)
+      updateRequest.packageUuid shouldBe newPackage.uuid
+      queuedPackages.map(_.packageUuid) should contain(newPackage.uuid)
     }
   }
 
   property("queuing an update for a blacklisted package fails") {
     val newPackage = PackageGen.sample.get
-    val req = updateRequestGen(defaultNs, PackageIdGen).sample.get.copy(packageId = newPackage.id)
+    val req = updateRequestGen(Gen.uuid).sample.get.copy(packageUuid = newPackage.uuid)
 
     val f = for {
       packageM <- db.run(Packages.create(newPackage))
       _ <- BlacklistedPackages.create(packageM.namespace, packageM.id)
-      _ <- service.queueUpdate(req, _ => Future.successful(Map.empty))
+      _ <- service.queueUpdate(defaultNs, req, _ => Future.successful(Map.empty))
     } yield packageM
 
     val e = f.failed.futureValue
@@ -160,14 +160,14 @@ class UpdateServiceSpec extends PropSpec
     val newPackage = PackageGen.sample.get
     val dependency = PackageGen.sample.get
     val device = DeviceGenerators.genId.sample.get
-    val req = updateRequestGen(defaultNs, PackageIdGen).sample.get.copy(packageId = newPackage.id)
+    val req = updateRequestGen(Gen.uuid).sample.get.copy(packageUuid = newPackage.uuid)
     val fakeDependency = Map(device -> Set(dependency.id))
 
     val f = for {
       packageM <- db.run(Packages.create(newPackage))
       _ <- db.run(Packages.create(dependency))
       _ <- BlacklistedPackages.create(dependency.namespace, dependency.id)
-      _ <- service.queueUpdate(req, _ => Future.successful(fakeDependency))
+      _ <- service.queueUpdate(defaultNs, req, _ => Future.successful(fakeDependency))
     } yield packageM
 
     val throwableF = f.failed.futureValue

--- a/core/src/test/scala/org/genivi/sota/core/transfer/DeviceUpdatesSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/DeviceUpdatesSpec.scala
@@ -70,8 +70,8 @@ class DeviceUpdatesSpec extends FunSuite
       report = UpdateReport(updateSpec.request.id, List(result))
       _ <- reportInstall(device.id, report, MessageBusPublisher.ignore)
       updatedSpec <- db.run(findUpdateSpecFor(device.id, updateSpec.request.id))
-      history <- db.run(InstallHistories.list(device.namespace, device.id))
-    } yield (updatedSpec.status, history)
+      history <- db.run(InstallHistories.list(device.id))
+    } yield (updatedSpec.status, history.map(_._1))
 
     whenReady(f) { case (newStatus, history) =>
       newStatus should be(UpdateStatus.Finished)
@@ -195,13 +195,9 @@ class DeviceUpdatesSpec extends FunSuite
         // check update spec 0 status finished
         // check update spec 1 status failed
         // check update spec 2 status canceled
-        val (_, _, vin0, status0, installPos0, _, _) = usRow0
-        val (_, _, vin1, status1, installPos1, _, _) = usRow1
-        val (_, _, vin2, status2, installPos2, _, _) = usRow2
-
-        status0 shouldBe UpdateStatus.Finished
-        status1 shouldBe UpdateStatus.Failed
-        status2 shouldBe UpdateStatus.Pending
+        usRow0.status shouldBe UpdateStatus.Finished
+        usRow1.status shouldBe UpdateStatus.Failed
+        usRow2.status shouldBe UpdateStatus.Pending
       }
 
     }
@@ -238,13 +234,9 @@ class DeviceUpdatesSpec extends FunSuite
         // check update spec 0 status finished
         // check update spec 1 status failed
         // check update spec 2 status canceled
-        val (_, _, device0, status0, installPos0, _, _) = usRow0
-        val (_, _, device1, status1, installPos1, _, _) = usRow1
-        val (_, _, device2, status2, installPos2, _, _) = usRow2
-
-        status0 shouldBe UpdateStatus.Finished
-        status1 shouldBe UpdateStatus.Failed
-        status2 shouldBe UpdateStatus.Pending
+        usRow0.status shouldBe UpdateStatus.Finished
+        usRow1.status shouldBe UpdateStatus.Failed
+        usRow2.status shouldBe UpdateStatus.Pending
       }
 
     }

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -51,9 +51,9 @@ object DataGenerators {
 
   def updateWithDependencies(device: Device.Id) : Gen[(UpdateRequest, UpdateService.DeviceToPackageIds)] =
     for {
-      packageId    <- Gen.oneOf( packages.map( _.id) )
-      request      <- updateRequestGen(Namespaces.defaultNs, packageId)
-      dependencies <- dependenciesGen( packageId, device )
+      pkg    <- Gen.oneOf(packages)
+      request      <- updateRequestGen(pkg.uuid)
+      dependencies <- dependenciesGen(pkg.id, device)
     } yield (request, dependencies)
 
   def requestsGen(device: Device.Id): Gen[Map[UpdateRequest, UpdateService.DeviceToPackageIds]] = for {
@@ -228,7 +228,7 @@ class PackageUpdateSpec extends PropSpec
     for {
       specs <- Future.sequence( generatedData.map {
                                  case (request, deps) =>
-                                   updateService.queueUpdate(request, _ => FastFuture.successful(deps))
+                                   updateService.queueUpdate(defaultNs, request, _ => FastFuture.successful(deps))
                                })
     } yield specs.foldLeft(Set.empty[UpdateSpec])(_ union _)
 

--- a/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
@@ -24,7 +24,7 @@ object UpdateNotifierSpec {
 
   def updateSpecGen(namespaceGen: Gen[Namespace], deviceGen: Gen[Device.Id]) : Gen[UpdateSpec] = for {
     ns            <- namespaceGen
-    updateRequest <- updateRequestGen(ns, Gen.oneOf(packages).map( _.id) )
+    updateRequest <- updateRequestGen(Gen.oneOf(packages).map( _.uuid) )
     device        <- deviceGen
     m             <- Gen.choose(1, 10)
     packages      <- Gen.pick(m, packages).map( _.toSet )


### PR DESCRIPTION
Maintains uniqueness on previous composite pk, (namespace, name,
version)

This simplifies all queries and code related to packages as namespace,
name and version are now simple attributes of a Package entity, so the
code does not need to deal with them if they will not be used.

This simplification also made it possible to remove the `namespace`
column on all tables except Package, all other entities are linked by a
Package, so this is redundant.

https://advancedtelematic.atlassian.net/browse/PRO-1197