### PR TITLE
Add request query to logs.

### DIFF
--- a/common/src/main/scala/org/genivi/sota/http/LogDirectives.scala
+++ b/common/src/main/scala/org/genivi/sota/http/LogDirectives.scala
@@ -42,6 +42,7 @@ object LogDirectives {
     Map(
       "method" -> request.method.name,
       "path" -> request.uri.path.toString,
+      "query" -> s"'${request.uri.rawQueryString.getOrElse("").toString}'",
       "stime" -> serviceTime.toString,
       "status" -> response.status.intValue.toString
     )


### PR DESCRIPTION
Adds `query=[...]` to the log output, e.g.:

```
I|09:21:06.413|akka.actor.ActorSystemImpl|method=GET path=/api/v1/devices query=regex=.*&namespace=default service_name=device-registry stime=19 status=200
I|09:21:16.888|akka.actor.ActorSystemImpl|method=POST path=/api/v1/devices/124415cb-a1d1-4753-bc16-321984af52da/ping query= service_name=device-registry stime=99 status=200
```

/cc @alaa: Not sure if this requires changes to Kibana?