### PR TITLE
use retryUntil instead of suchThat

### DIFF
--- a/device-registry/src/test/scala/org/genivi/sota/device_registry/DeviceResourceSpec.scala
+++ b/device-registry/src/test/scala/org/genivi/sota/device_registry/DeviceResourceSpec.scala
@@ -117,7 +117,7 @@ class DeviceResourceSpec extends ResourcePropSpec {
     import scala.util.Random
 
     def injectSubstr(s: String, substr: String): String = {
-      val pos = Random.nextInt(s.length)
+      val pos = Random.nextInt(s.length + 1)
       s.take(pos) ++ substr ++ s.drop(pos)
     }
 


### PR DESCRIPTION
suchThat doesn't really try hard to fulfill the property; e.g.
```Gen.containerOfN(10, arbitrary[Int]).suchThat { c => c.distinct.length == c.length }```
would fail most of the time, whereas
```Gen.containerOfN(10, arbitrary[Int]).retryUntil { c => c.distinct.length == c.length }```
works well, at least for small N