### PR TITLE
[WIP] Bugfix/pro 1303/auth ns for device registry

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
@@ -18,12 +18,12 @@ trait DeviceRegistry {
 
   // TODO: Needs namespace
   def searchDevice
-    (ns: Namespace, re: String Refined Regex)
+    (re: String Refined Regex)
     (implicit ec: ExecutionContext): Future[Seq[Device]]
 
-  def listNamespace(ns: Namespace)
+  def listNamespace()
   (implicit ec: ExecutionContext): Future[Seq[Device]] =
-    searchDevice(ns, Refined.unsafeApply(".*"))
+    searchDevice(Refined.unsafeApply(".*"))
 
   def createDevice
   (device: DeviceT)

--- a/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
+++ b/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
@@ -39,10 +39,10 @@ class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri)
 
   private val http = Http()
 
-  override def searchDevice(ns: Namespace, re: String Refined Regex)
+  override def searchDevice(re: String Refined Regex)
                            (implicit ec: ExecutionContext): Future[Seq[Device]] =
     execHttp[Seq[Device]](HttpRequest(uri = baseUri.withPath(devicesUri.path)
-      .withQuery(Query("regex" -> re.get, "namespace" -> ns.get))))
+      .withQuery(Query("regex" -> re.get))))
       .recover { case t =>
         log.error(t, "Could not contact device registry")
         Seq.empty[Device]

--- a/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
@@ -36,7 +36,7 @@ class FakeDeviceRegistry(namespace: Namespace)
   private val systemInfo = new ConcurrentHashMap[Uuid, Json]()
 
   override def searchDevice
-  (ns: Namespace, re: String Refined Regex)
+  (re: String Refined Regex)
   (implicit ec: ExecutionContext): Future[Seq[Device]] = {
     FastFuture.successful(
       devices

--- a/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
@@ -60,11 +60,11 @@ class DevicesResource(db: Database, client: ConnectivityClient,
   /**
     * An ota client GET a Seq of [[Device]] from regex/status search.
     */
-  def search(ns: Namespace): Route = {
+  def search(): Route = {
     parameters(('status.?(false), 'regex.as[RefinedRegx].?)) {
       (includeStatus: Boolean, reqRegex: Option[RefinedRegx]) =>
         val regex = reqRegex.getOrElse(Refined.unsafeApply(".*")) // TODO optimize or forbid
-        val devices = deviceRegistry.searchDevice(ns, regex)
+        val devices = deviceRegistry.searchDevice(regex)
 
         if (includeStatus) {
           val f = DeviceSearch.fetchDeviceStatus(devices)
@@ -108,7 +108,7 @@ class DevicesResource(db: Database, client: ConnectivityClient,
   }
 
   val route =
-    (pathPrefix("devices") & namespaceExtractor) { ns =>
-      (pathEnd & get) { search(ns) }
+    pathPrefix("devices") {
+      (pathEnd & get) { search() }
     }
 }

--- a/core/src/main/scala/org/genivi/sota/core/UpdateRequestsResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/UpdateRequestsResource.scala
@@ -75,7 +75,7 @@ class UpdateRequestsResource(db: Database, resolver: ExternalResolverClient, upd
     import ResponseConversions._
 
     clientUpdateRequest(ns) { case (creq: ClientUpdateRequest, req: UpdateRequest) =>
-      val resultF = updateService.queueUpdate(ns, req, pkg => resolver.resolve(ns, pkg.id))
+      val resultF = updateService.queueUpdate(ns, req, pkg => resolver.resolve(pkg.id))
       complete(resultF.map (_ => (StatusCodes.Created, req.toResponse(creq.packageId))))
     }
   }

--- a/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
+++ b/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
@@ -44,7 +44,7 @@ trait ExternalResolverClient {
     * @param packageId The name and version of the package
     * @return Which packages need to be installed on which vehicles
     */
-  def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Uuid, Set[PackageId]]]
+  def resolve(packageId: PackageId): Future[Map[Uuid, Set[PackageId]]]
 
   /**
     * Update the list of packages that are installed on a vehicle.
@@ -121,11 +121,10 @@ class DefaultExternalResolverClient(baseUri : Uri, resolveUri: Uri, packagesUri:
 
   private[this] val log = Logging( system, "org.genivi.sota.externalResolverClient" )
 
-  override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = {
+  override def resolve(packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = {
     val resolvePath = resolveUri
       .withPath(resolveUri.path)
       .withQuery(Query(
-        "namespace" -> namespace.get,
         "package_name" -> packageId.name.get,
         "package_version" -> packageId.version.get
       ))

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -31,7 +31,7 @@ class FakeExternalResolver()(implicit system: ActorSystem, mat: ActorMaterialize
     Future.successful(())
   }
 
-  override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = {
+  override def resolve(packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = {
     Future.successful(Map.empty)
   }
 

--- a/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
@@ -52,7 +52,7 @@ class PackageUploadSpec extends PropSpec
     val resolver = new ExternalResolverClient {
       override def putPackage(namespace: Namespace, packageId: PackageId, description: Option[String], vendor: Option[String]): Future[Unit] = resolverResult
 
-      override def resolve(namespace: Namespace, packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = ???
+      override def resolve(packageId: PackageId): Future[Map[Uuid, Set[PackageId]]] = ???
 
       override def setInstalledPackages(device: Uuid, json: io.circe.Json) : Future[Unit] = ???
 

--- a/device-registry/src/main/resources/db/migration/V7__unique_index.sql
+++ b/device-registry/src/main/resources/db/migration/V7__unique_index.sql
@@ -1,0 +1,7 @@
+create unique index `Device_unique_device_name` on
+`Device` (`namespace`, `device_name`)
+;
+
+create unique index `Device_unique_device_id` on
+`Device` (`namespace`, `device_name`)
+;

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/DeviceRepository.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/DeviceRepository.scala
@@ -13,8 +13,7 @@ import io.circe.jawn._
 
 import org.genivi.sota.data.{Device, DeviceT, Namespace, Uuid}
 import org.genivi.sota.data.Namespace._
-import org.genivi.sota.db.Operators.regex
-import org.genivi.sota.db.SlickExtensions._
+import org.genivi.sota.db.Operators._
 import org.genivi.sota.device_registry.common.Errors
 import org.genivi.sota.refined.SlickRefined._
 import java.time.Instant
@@ -25,6 +24,7 @@ import slick.driver.MySQLDriver.api._
 
 
 object DeviceRepository {
+  import org.genivi.sota.db.SlickExtensions._
 
   import Device._
 
@@ -54,6 +54,9 @@ object DeviceRepository {
       ((Device.apply _).tupled, Device.unapply)
 
     def pk = primaryKey("uuid", uuid)
+
+    def uniqueName = index("Device_unique_device_name", (namespace, deviceName), unique = true)
+    def uniqueDeviceId = index("Device_unique_device_id", (namespace, deviceId), unique = true)
   }
 
   // scalastyle:on
@@ -62,29 +65,12 @@ object DeviceRepository {
   def list(ns: Namespace): DBIO[Seq[Device]] = devices.filter(_.namespace === ns).result
 
   def create(ns: Namespace, device: DeviceT)
-             (implicit ec: ExecutionContext): DBIO[Uuid] = {
+            (implicit ec: ExecutionContext): DBIO[Uuid] = {
     val uuid: Uuid = Uuid.generate()
 
-    val dbIO = for {
-      _ <- exists(ns, uuid).asTry.flatMap {
-        case Success(_) => DBIO.failed(Errors.ConflictingDevice)
-        case Failure(_) => DBIO.successful(())
-      }
-      _ <- notConflicts(ns, device.deviceName, device.deviceId)
-      _ <- devices += Device(ns, uuid, device.deviceName, device.deviceId, device.deviceType)
-    } yield uuid
-
-    dbIO.transactionally
-  }
-
-  def notConflicts(ns: Namespace, deviceName: DeviceName, deviceId: Option[DeviceId])
-                  (implicit ec: ExecutionContext): DBIO[Unit] = {
-    devices
-      .filter(_.namespace === ns)
-      .filter(d => d.deviceName === deviceName || d.deviceId === deviceId)
-      .exists
-      .result
-      .flatMap(if (_) DBIO.failed(Errors.ConflictingDevice) else DBIO.successful(()))
+    (devices += Device(ns, uuid, device.deviceName, device.deviceId, device.deviceType))
+      .handleIntegrityErrors(Errors.ConflictingDevice)
+      .map(_ => uuid)
   }
 
   def exists(ns: Namespace, uuid: Uuid)
@@ -92,9 +78,7 @@ object DeviceRepository {
     devices
       .filter(d => d.namespace === ns && d.uuid === uuid)
       .result
-      .headOption
-      .flatMap(_.
-        fold[DBIO[Device]](DBIO.failed(Errors.MissingDevice))(DBIO.successful))
+      .failIfNotSingle(Errors.MissingDevice)
 
   def findByDeviceId(ns: Namespace, deviceId: DeviceId)
                     (implicit ec: ExecutionContext): DBIO[Seq[Device]] =
@@ -107,38 +91,33 @@ object DeviceRepository {
       .filter(d => d.namespace === ns && regex(d.deviceName, re))
       .result
 
-  def update(ns: Namespace, uuid: Uuid, device: DeviceT)
-            (implicit ec: ExecutionContext): DBIO[Unit] = {
-
-    val dbIO = for {
-      _ <- exists(ns, uuid)
-      _ <- notConflicts(ns, device.deviceName, device.deviceId)
-      _ <- devices.update(Device(ns, uuid, device.deviceName, device.deviceId, device.deviceType))
-    } yield ()
-
-    dbIO.transactionally
-  }
-
-  def findByUuid(uuid: Uuid)(implicit ec: ExecutionContext): DBIO[Device] = {
+  def findByUuid(uuid: Uuid)(implicit ec: ExecutionContext): DBIO[Device] =
     devices
       .filter(_.uuid === uuid)
       .result
-      .headOption
-      .flatMap(_.fold[DBIO[Device]](DBIO.failed(Errors.MissingDevice))(DBIO.successful))
-  }
+      .failIfNotSingle(Errors.MissingDevice)
+
+  def update(uuid: Uuid, device: DeviceT)
+            (implicit ec: ExecutionContext): DBIO[Unit] =
+    devices
+      .filter(_.uuid === uuid)
+      .map (d => (d.deviceName, d.deviceId, d.deviceType))
+      .update((device.deviceName, device.deviceId, device.deviceType))
+      .handleIntegrityErrors(Errors.ConflictingDevice)
+      .map (_ => ())
 
   def updateLastSeen(uuid: Uuid)
-                    (implicit ec: ExecutionContext): DBIO[Unit] = for {
-    device <- findByUuid(uuid)
-    newDevice = device.copy(lastSeen = Some(Instant.now()))
-    _ <- devices.insertOrUpdate(newDevice)
-  } yield ()
+                    (implicit ec: ExecutionContext): DBIO[Unit] =
+    devices
+      .filter (_.uuid === uuid)
+      .map (_.lastSeen)
+      .update(Some(Instant.now()))
+      .map (_ => ())
 
-  def delete(ns: Namespace, uuid: Uuid)
+  def delete(uuid: Uuid)
             (implicit ec: ExecutionContext): DBIO[Unit] = {
     val dbIO = for {
-      _ <- exists(ns, uuid)
-      _ <- devices.filter(d => d.namespace === ns && d.uuid === uuid).delete
+      _ <- devices.filter(_.uuid === uuid).delete
       _ <- SystemInfo.delete(uuid)
     } yield ()
 

--- a/docs/swagger/sota-device_registry.yml
+++ b/docs/swagger/sota-device_registry.yml
@@ -18,12 +18,7 @@ produces:
 paths:
   /devices:
     get:
-      description: 'Get a list of all the devices in a particular namespace in the device registry.'
-      parameters:
-      - name: namespace
-        in: query
-        required: true
-        type: string
+      description: 'Get a list of all the devices in the current namespace in the device registry.'
       responses:
         200:
           description: OK

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/DbDepResolver.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/DbDepResolver.scala
@@ -46,7 +46,7 @@ object DbDepResolver {
              (implicit db: Database, ec: ExecutionContext,
               mat: Materializer): Future[Map[Uuid, Seq[PackageId]]] = {
     for {
-      devices <- deviceRegistry.listNamespace(namespace)
+      devices <- deviceRegistry.listNamespace()
       filtersForPkg <- db.run(PackageFilterRepository.listFiltersForPackage(namespace, pkgId))
       vf <- filterDevices(namespace,
                           devices.map(d => (d.uuid, d.deviceId)).toMap,

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/DeviceRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/DeviceRepository.scala
@@ -244,7 +244,7 @@ object DeviceRepository {
     val filter = And(vins, And(pkgs, comps))
 
     for {
-      devices <- deviceRegistry.listNamespace(namespace)
+      devices <- deviceRegistry.listNamespace()
       searchResult <- DbDepResolver.filterDevices(namespace, devices.map(d => d.uuid -> d.deviceId).toMap, filter)
     } yield searchResult
   }

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
@@ -46,8 +46,8 @@ class ResolveDirectives(namespaceExtractor: Directive1[Namespace],
     (get &
       encodeResponse &
       pathPrefix("resolve") &
-      parameter('namespace.as[Namespace]) & refinedPackageIdParams) { (ns, id) =>
-      resolvePackage(ns, id)
+      namespaceExtractor & refinedPackageIdParams) { (ns, id) =>
+        resolvePackage(ns, id)
     }
   }
 }


### PR DESCRIPTION
https://advancedtelematic.atlassian.net/browse/PRO-1303

This commit makes sure that all end-points for the device registry is only working with the namespace from namespaceExtractor. This means that the query parameter namespace from the endpoind /api/v1/devices, have been removed and instead only the namespace from the extractor is used.

At the same time I have updated DeviceRepository to use unique indices for deviceName and deviceId. This make it so instead of checking notConflicts before making an insert/update, we perform the action and SQL will throw an error if there was a conflict.
