### PR TITLE
[PRO-1392] Actually launch the campaigns

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
@@ -33,6 +33,10 @@ trait DeviceRegistry {
     (uuid: Uuid)
     (implicit ec: ExecutionContext): Future[Device]
 
+  def fetchGroup
+    (uuid: Uuid)
+    (implicit ec: ExecutionContext): Future[Seq[Uuid]]
+
   def fetchByDeviceId
     (ns: Namespace, deviceId: DeviceId)
     (implicit ec: ExecutionContext): Future[Device]

--- a/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
+++ b/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
@@ -26,7 +26,7 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri)
+class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri, deviceGroupsUri: Uri)
                           (implicit system: ActorSystem, mat: ActorMaterializer)
     extends DeviceRegistry {
 
@@ -60,6 +60,10 @@ class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri)
   override def fetchDevice(uuid: Uuid)
                           (implicit ec: ExecutionContext): Future[Device] =
     execHttp[Device](HttpRequest(uri = baseUri.withPath(devicesUri.path / uuid.show)))
+
+  override def fetchGroup(uuid: Uuid)
+                         (implicit ec: ExecutionContext): Future[Seq[Uuid]] =
+    execHttp[Seq[Uuid]](HttpRequest(uri = baseUri.withPath(deviceGroupsUri.path / uuid.show / "devices")))
 
   override def fetchByDeviceId(ns: Namespace, deviceId: DeviceId)
                               (implicit ec: ExecutionContext): Future[Device] =

--- a/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
@@ -69,6 +69,9 @@ class FakeDeviceRegistry(namespace: Namespace)
     }
   }
 
+  override def fetchGroup(uuid: Uuid)
+                         (implicit ec: ExecutionContext): Future[Seq[Uuid]] = FastFuture.successful(Seq())
+
   override def fetchByDeviceId
   (ns: Namespace, deviceId: DeviceId)
   (implicit ec: ExecutionContext): Future[Device] =
@@ -97,6 +100,7 @@ class FakeDeviceRegistry(namespace: Namespace)
   (uuid: Uuid)
   (implicit ec: ExecutionContext): Future[Unit] = {
     devices.remove(uuid)
+    systemInfo.remove(uuid)
     FastFuture.successful(())
   }
 

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -58,6 +58,7 @@ device_registry = {
   baseUri = "http://localhost:8083"
   baseUri = ${?DEVICE_REGISTRY_API_URI}
   devicesUri = "/api/v1/devices"
+  deviceGroupsUri = "/api/v1/device_groups"
 }
 
 upload {

--- a/core/src/main/resources/db/migration/V23__campaign_update_request.sql
+++ b/core/src/main/resources/db/migration/V23__campaign_update_request.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `CampaignGroups`
+DROP COLUMN `group_name`,
+DROP PRIMARY KEY,
+ADD `group_uuid` CHAR(36) NOT NULL,
+ADD PRIMARY KEY (campaign_id, group_uuid),
+ADD `update_request_id` CHAR(36) NULL,
+ADD FOREIGN KEY Campaign_update_request_id_fk (update_request_id) REFERENCES UpdateRequest(update_request_id);

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -105,6 +105,7 @@ class Settings(val config: Config) {
 
   val deviceRegistryUri = Uri(config.getString("device_registry.baseUri"))
   val deviceRegistryApi = Uri(config.getString("device_registry.devicesUri"))
+  val deviceRegistryGroupApi = Uri(config.getString("device_registry.deviceGroupsUri"))
 
   val rviSotaUri = Uri(config.getString("rvi.sotaServicesUri"))
   val rviEndpoint = Uri(config.getString("rvi.endpoint"))
@@ -131,7 +132,7 @@ object Boot extends App with DatabaseConfig with HttpBoot with RviBoot with Boot
   )
 
   val deviceRegistryClient = new DeviceRegistryClient(
-    settings.deviceRegistryUri, settings.deviceRegistryApi
+    settings.deviceRegistryUri, settings.deviceRegistryApi, settings.deviceRegistryGroupApi
   )
 
   val messageBusPublisher: MessageBusPublisher =

--- a/core/src/main/scala/org/genivi/sota/core/CampaignLauncher.scala
+++ b/core/src/main/scala/org/genivi/sota/core/CampaignLauncher.scala
@@ -1,0 +1,46 @@
+/**
+  * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+  * License: MPL-2.0
+  */
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import cats.Foldable
+import cats.implicits._
+import org.genivi.sota.core.data.Campaign
+import org.genivi.sota.core.db.Campaigns
+import org.genivi.sota.common.DeviceRegistry
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
+import scala.concurrent.{ExecutionContext, Future}
+import slick.driver.MySQLDriver.api.Database
+
+object CampaignLauncher {
+  import Campaign._
+  import UpdateService._
+
+  def resolve(devices: Seq[Uuid]): DependencyResolver = { pkg =>
+    Future.successful(devices.map(_ -> Set(pkg.id)).toMap)
+  }
+
+  def launch (deviceRegistry: DeviceRegistry, updateService: UpdateService, id: Campaign.Id)
+             (implicit db: Database, system: ActorSystem, ec: ExecutionContext): Future[List[Uuid]] = {
+    def launchGroup (ns: Namespace, pkgId: PackageId, campGrp: CampaignGroup): Future[Uuid] = {
+      val groupId = campGrp.group
+      for {
+        updateRequest <- updateService.updateRequest(ns, pkgId)
+
+        devices <- deviceRegistry.fetchGroup(groupId)
+        _ <- updateService.queueUpdate(ns, updateRequest, resolve(devices))
+
+        uuid = Uuid.fromJava(updateRequest.id)
+        _ <- db.run(Campaigns.setUpdateUuid(id, groupId, uuid))
+      } yield uuid
+    }
+
+    for {
+      camp <- db.run(Campaigns.setAsLaunch(id))
+      updateRefs <- camp.groups.toList.traverse(campGrp =>
+        launchGroup(camp.meta.namespace, camp.packageId.get, campGrp))
+    } yield updateRefs
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/CampaignResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/CampaignResource.scala
@@ -11,81 +11,74 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{AuthorizationFailedRejection, Directive1, Route}
 import akka.http.scaladsl.unmarshalling._
 import akka.http.scaladsl.util.FastFuture
-import akka.stream.ActorMaterializer
 import io.circe.generic.auto._
-import org.genivi.sota.core.data.Campaign
+import org.genivi.sota.core.data.{Campaign, UpdateRequest}
 import org.genivi.sota.core.db.Campaigns
-import org.genivi.sota.data.{Namespace, PackageId}
+import org.genivi.sota.common.DeviceRegistry
+import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
 import org.genivi.sota.http.ErrorHandler
+import org.genivi.sota.http.UuidDirectives._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
-import org.genivi.sota.rest.Validation.{refined}
+import org.genivi.sota.rest.Validation.refined
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 import slick.driver.MySQLDriver.api.Database
 
-class CampaignResource(db: Database, namespaceExtractor: Directive1[Namespace])
-                      (implicit system: ActorSystem, mat: ActorMaterializer) {
+class CampaignResource(namespaceExtractor: Directive1[Namespace],
+                       deviceRegistry: DeviceRegistry, updateService: UpdateService)
+                      (implicit db: Database, system: ActorSystem) {
+  import system.dispatcher
 
   import StatusCodes.{Success => _, _}
   import Campaign._
 
-  def createCampaign(ns: Namespace, name: CreateCampaign)
-                    (implicit ec: ExecutionContext): Route = {
+  def createCampaign(ns: Namespace, name: CreateCampaign): Route = {
     complete(Created -> db.run(Campaigns.create(ns, name.name)))
   }
 
-  def deleteCampaign(id: Campaign.Id)
-                    (implicit ec: ExecutionContext): Route = {
+  def deleteCampaign(id: Campaign.Id): Route = {
     complete(db.run(Campaigns.delete(id)))
   }
 
-  def fetchCampaign(id: Campaign.Id)
-                   (implicit ec: ExecutionContext): Route = {
+  def fetchCampaign(id: Campaign.Id): Route = {
     complete(db.run(Campaigns.fetch(id)))
+  }
+
+  def launch(id: Campaign.Id): Route = {
+    complete(CampaignLauncher.launch(deviceRegistry, updateService, id))
   }
 
   def listCampaigns(ns: Namespace): Route = {
     complete(db.run(Campaigns.list(ns)))
   }
 
-  def setAsDraft(id: Campaign.Id)
-                (implicit ec: ExecutionContext): Route = {
+  def setAsDraft(id: Campaign.Id): Route = {
     complete(db.run(Campaigns.setAsDraft(id)))
   }
 
-  def setAsLaunch(id: Campaign.Id)
-                 (implicit ec: ExecutionContext): Route = {
-    complete(db.run(Campaigns.setAsLaunch(id)))
-  }
-
-  def setCampaignGroups(id: Campaign.Id, groups: CampaignGroups)
-                       (implicit ec: ExecutionContext): Route = {
+  def setCampaignGroups(id: Campaign.Id, groups: SetCampaignGroups): Route = {
     complete(db.run(Campaigns.setGroups(id, groups.groups)))
   }
 
-  def setCampaignName(id: Campaign.Id, name: CreateCampaign)
-                       (implicit ec: ExecutionContext): Route = {
+  def setCampaignName(id: Campaign.Id, name: CreateCampaign): Route = {
     complete(db.run(Campaigns.setName(id, name.name)))
   }
 
-  def setCampaignPackage(id: Campaign.Id, pkg: PackageId)
-                        (implicit ec: ExecutionContext): Route = {
+  def setCampaignPackage(id: Campaign.Id, pkg: PackageId): Route = {
     complete(db.run(Campaigns.setPackage(id, pkg)))
   }
 
-  def extractId(ns: Namespace): Directive1[Campaign.Id] =
-    refined[Campaign.ValidId](Slash ~ Segment).map(Campaign.Id).flatMap { id =>
-      extractExecutionContext.flatMap { implicit ec =>
-        val f = db.run(Campaigns.exists(ns, id))
+  def campaignAllowed(id: Campaign.Id): Future[Namespace] = {
+    db.run(Campaigns.fetchMeta(id).map(_.namespace))
+  }
 
-        onSuccess(f).flatMap { _ => provide(id) }
-      }
-    }
+  val extractId: Directive1[Campaign.Id] =
+    allowExtractor(namespaceExtractor, extractUuid.map(Campaign.Id(_)), campaignAllowed)
 
   val route = ErrorHandler.handleErrors {
     extractExecutionContext { implicit ec =>
-      (pathPrefix("campaigns") & namespaceExtractor) { ns =>
-        pathEnd {
+      pathPrefix("campaigns") {
+        (pathEnd & namespaceExtractor) { ns =>
           get {
             listCampaigns(ns)
           } ~
@@ -93,7 +86,7 @@ class CampaignResource(db: Database, namespaceExtractor: Directive1[Namespace])
             createCampaign(ns, name)
           }
         } ~
-        extractId(ns) { id =>
+        extractId { id =>
           pathEnd {
             get {
               fetchCampaign(id)
@@ -106,9 +99,9 @@ class CampaignResource(db: Database, namespaceExtractor: Directive1[Namespace])
             setAsDraft(id)
           } ~
           (path("launch") & post) {
-            setAsLaunch(id)
+            launch(id)
           } ~
-          (path("groups") & put & entity(as[CampaignGroups])) { groups =>
+          (path("groups") & put & entity(as[SetCampaignGroups])) { groups =>
             setCampaignGroups(id, groups)
           } ~
           (path("name") & put & entity(as[CreateCampaign])) { campName =>

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -29,7 +29,6 @@ class WebService(notifier: UpdateNotifier,
 
   import org.genivi.sota.http.ErrorHandler._
 
-  val campaignResource = new CampaignResource(db, authNamespace)
   val devicesResource = new DevicesResource(db, connectivity.client, resolver, deviceRegistry, authNamespace)
   val packagesResource = new PackagesResource(resolver, db, messageBusPublisher, authNamespace)
   val updateService = new UpdateService(notifier, deviceRegistry)
@@ -37,6 +36,7 @@ class WebService(notifier: UpdateNotifier,
   val historyResource = new HistoryResource(authNamespace)(db, system)
   val blacklistResource = new BlacklistResource(authNamespace, messageBusPublisher)(db, system)
   val impactResource = new ImpactResource(authNamespace, resolver)(db, system)
+  val campaignResource = new CampaignResource(authNamespace, deviceRegistry, updateService)(db, system)
 
   val route = (handleErrors & pathPrefix("api" / "v1")) {
     campaignResource.route ~

--- a/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
@@ -7,43 +7,38 @@ package org.genivi.sota.core.data
 import cats.Show
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
+import io.circe._
+import io.circe.generic.auto._
 import java.time.Instant
 import java.util.UUID
-import org.genivi.sota.data.{GroupInfo, Namespace, PackageId}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import slick.driver.MySQLDriver.api._
 
 import Campaign._
 
-case class Campaign (meta: CampaignMeta, packageId: Option[PackageId], groups: Seq[GroupInfo.Name]) {
+case class Campaign (meta: CampaignMeta, packageId: Option[PackageId], groups: Seq[CampaignGroup]) {
   def canLaunch(): Boolean = meta.packageUuid.isDefined && groups.size > 0
 }
 
 object Campaign {
   case class CampaignMeta(
-    id: Campaign.Id,
+    id: Id,
     namespace: Namespace,
     name : String,
     launched: Boolean = false,
-    packageUuid: Option[UUID] = None
+    packageUuid: Option[Uuid] = None
   )
   case class CreateCampaign(name: String)
-  case class CampaignGroups(groups: Seq[GroupInfo.Name])
+  case class SetCampaignGroups(groups: Seq[Uuid])
+  case class CampaignGroup(group: Uuid, updateRequest: Option[Uuid])
 
-  type ValidId = Uuid
-  case class Id(underlying: String Refined ValidId) extends AnyVal
+  final case class Id(underlying: Uuid)
 
-  object ValidId {
-    def from(uuid: UUID): Id = Id(Refined.unsafeApply(uuid.toString))
-  }
+  implicit val idDecoder: Decoder[Id] = Decoder[UUID].map(uuid => Id(Uuid.fromJava(uuid)))
+  implicit val idEncoder: Encoder[Id] = Encoder[UUID].contramap(_.underlying.toJava)
 
-  implicit val showId = new Show[Id] {
-    def show(id: Id) = id.underlying.get
-  }
-
-  implicit val IdOrdering: Ordering[Id] = new Ordering[Id] {
-    override def compare(id1: Id, id2: Id): Int = id1.underlying.get compare id2.underlying.get
-  }
+  implicit val showId: Show[Id] = Show.show(id => Uuid.showUuid.show(id.underlying))
 
   implicit val idColumnType =
-    MappedColumnType.base[Id, String](showId.show, (s: String) => Id(Refined.unsafeApply(s)))
+    MappedColumnType.base[Id, Uuid](_.underlying, Id(_))
 }

--- a/core/src/main/scala/org/genivi/sota/core/db/Campaigns.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Campaigns.scala
@@ -9,7 +9,7 @@ import java.time.Instant
 import java.util.UUID
 import org.genivi.sota.core.data.{Campaign, Package}
 import org.genivi.sota.core.SotaCoreErrors
-import org.genivi.sota.data.{GroupInfo, Namespace, PackageId}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.genivi.sota.db.Operators._
 import org.genivi.sota.refined.SlickRefined._
 import scala.concurrent.ExecutionContext
@@ -23,7 +23,7 @@ object Campaigns {
 
   // scalastyle:off
   class CampaignTable(tag: Tag) extends Table[CampaignMeta](tag, "Campaign") {
-    def id = column[Id]("uuid")
+    def id = column[Campaign.Id]("uuid")
     def namespace = column[Namespace]("namespace")
     def name = column[String]("name")
     def launched = column[Boolean]("launched")
@@ -32,19 +32,25 @@ object Campaigns {
     def pk = primaryKey("pk_campaign", id)
 
     def * = (id, namespace, name, launched, packageUuid).shaped <>
-      ((CampaignMeta.apply _).tupled, CampaignMeta.unapply)
+      (x => CampaignMeta(x._1, x._2, x._3, x._4, x._5.map(Uuid.fromJava _))
+      ,(x: CampaignMeta) => Some((x.id, x.namespace, x.name, x.launched, x.packageUuid.map(_.toJava))))
 
     def uniqueName = index("Campaign_unique_name", (namespace, name), unique = true)
     def fkPkg = foreignKey("Campaign_pkg_fk", packageUuid, Packages.packages)(_.uuid)
   }
+  // scalastyle:on
 
-  class CampaignGroups(tag: Tag) extends Table[(Campaign.Id, GroupInfo.Name)](tag, "CampaignGroups") {
-    def campaignId = column[Campaign.Id]("campaign_id")
-    def group = column[GroupInfo.Name]("group_name")
+  // scalastyle:off
+  class CampaignGroups(tag: Tag) extends Table[(Campaign.Id, CampaignGroup)](tag, "CampaignGroups") {
+    def campaign = column[Campaign.Id]("campaign_id")
+    def group = column[Uuid]("group_uuid")
+    def update = column[Option[Uuid]]("update_request_id")
 
-    def pk = primaryKey("pk_campaign_group", (campaignId, group))
+    def pk = primaryKey("pk_campaign_group", (campaign, group))
 
-    def * = (campaignId, group)
+    def * = (campaign, group, update).shaped <>
+      (x => (x._1, CampaignGroup(x._2, x._3))
+      ,(x: (Campaign.Id, CampaignGroup)) => Some((x._1, x._2.group, x._2.updateRequest)))
 
   }
   // scalastyle:on
@@ -52,10 +58,10 @@ object Campaigns {
   val campaignsMeta = TableQuery[CampaignTable]
   val campaignsGroups = TableQuery[CampaignGroups]
 
-  def byId(id: Id): Query[CampaignTable, CampaignMeta, Seq]
+  def byId(id: Campaign.Id): Query[CampaignTable, CampaignMeta, Seq]
     = campaignsMeta.filter(_.id === id)
 
-  def canEdit(id: Id)
+  def canEdit(id: Campaign.Id)
              (implicit ec: ExecutionContext): DBIO[CampaignMeta] =
     byId(id)
       .filter (_.launched === false)
@@ -64,32 +70,24 @@ object Campaigns {
 
   def create(ns: Namespace, name: String)
             (implicit ec: ExecutionContext): DBIO[Campaign.Id] = {
-    val id: Id = Id(refineV[ValidId](UUID.randomUUID.toString).right.get)
+    val id: Campaign.Id = Id(Uuid.generate())
 
     (campaignsMeta += CampaignMeta(id, ns, name))
       .handleIntegrityErrors(ConflictingCampaign)
       .map(_ => id)
   }
 
-  def delete(id: Id)
+  def delete(id: Campaign.Id)
             (implicit ec: ExecutionContext): DBIO[Unit] = {
     val dbIO = for {
       _ <- campaignsMeta.filter(_.id === id).delete
-      _ <- campaignsGroups.filter(_.campaignId === id).delete
+      _ <- campaignsGroups.filter(_.campaign === id).delete
     } yield ()
 
     dbIO.transactionally
   }
 
-  def exists(ns: Namespace, id: Id)
-            (implicit ec: ExecutionContext): DBIO[CampaignMeta] =
-    campaignsMeta
-      .filter(c => c.namespace === ns && c.id === id)
-      .result
-      .failIfNotSingle(MissingCampaign)
-
-
-  def fetch(id: Id)
+  def fetch(id: Campaign.Id)
            (implicit ec: ExecutionContext): DBIO[Campaign] = {
     val dbIO = for {
       meta <- fetchMeta(id)
@@ -100,14 +98,14 @@ object Campaigns {
     dbIO.transactionally
   }
 
-  def fetchGroups(id: Id)
-                 (implicit ec: ExecutionContext): DBIO[Seq[GroupInfo.Name]] =
+  def fetchGroups(id: Campaign.Id)
+                 (implicit ec: ExecutionContext): DBIO[Seq[CampaignGroup]] =
     campaignsGroups
-      .filter(_.campaignId === id)
+      .filter(_.campaign === id)
       .result
       .map (_.map(_._2))
 
-  def fetchMeta(id: Id)
+  def fetchMeta(id: Campaign.Id)
                (implicit ec: ExecutionContext): DBIO[CampaignMeta] =
     byId(id)
       .result
@@ -116,45 +114,44 @@ object Campaigns {
   def fetchPackage(meta: CampaignMeta)
                   (implicit ec: ExecutionContext): DBIO[Option[PackageId]] =
     meta.packageUuid.fold[DBIO[Option[PackageId]]](DBIO.successful(None))( uuid =>
-      Packages.byUuid(uuid).map(p => Some(p.id))
+      Packages.byUuid(uuid.toJava).map(p => Some(p.id))
     )
 
   def list(ns: Namespace): DBIO[Seq[CampaignMeta]] = campaignsMeta.filter(_.namespace === ns).result
 
-  def setAsDraft(id:Id)
+  def setAsDraft(id: Campaign.Id)
                 (implicit ec: ExecutionContext): DBIO[Unit] =
     byId(id)
       .map(_.launched)
       .update(false)
       .handleSingleUpdateError(MissingCampaign)
 
-  def setAsLaunch(id: Id)
-                 (implicit ec: ExecutionContext): DBIO[Unit] = {
+  def setAsLaunch(id: Campaign.Id)
+                 (implicit ec: ExecutionContext): DBIO[Campaign] = {
     val dbIO = for {
-      meta <- fetchMeta(id)
-      groups <- fetchGroups(id)
-      newMeta <- if (Campaign(meta, None, groups).canLaunch()) {
-          DBIO.successful(meta.copy(launched = true))
+      camp <- fetch(id)
+      newMeta <- if (camp.canLaunch()) {
+          DBIO.successful(camp.meta.copy(launched = true))
         } else { DBIO.failed(SotaCoreErrors.CantLaunchCampaign) }
       _ <- campaignsMeta.insertOrUpdate(newMeta)
-    } yield ()
+    } yield (camp.copy(meta = newMeta))
 
     dbIO.transactionally
   }
 
-  def setGroups(id: Id, groups: Seq[GroupInfo.Name])
+  def setGroups(id: Campaign.Id, groups: Seq[Uuid])
                (implicit ec: ExecutionContext): DBIO[Unit] = {
-    val newGroups = groups.map((id, _))
+    val newGroups = groups.distinct.map( x => (id, CampaignGroup(x, None)))
     val dbIO = for {
       _ <- canEdit(id)
-      _ <- campaignsGroups.filter(_.campaignId === id).delete
+      _ <- campaignsGroups.filter(_.campaign === id).delete
       _ <- campaignsGroups ++= newGroups
     } yield ()
 
     dbIO.transactionally
   }
 
-  def setName(id: Id, name: String)
+  def setName(id: Campaign.Id, name: String)
              (implicit ec: ExecutionContext): DBIO[Unit] = {
     val dbIO = for {
       _ <- canEdit(id)
@@ -167,11 +164,22 @@ object Campaigns {
     dbIO.transactionally
   }
 
-  def setPackage(id: Id, pkgId: PackageId)
+  def setUpdateUuid(id: Campaign.Id, group: Uuid, update: Uuid)
+                 (implicit ec: ExecutionContext): DBIO[Unit] = {
+    campaignsGroups
+      .filter(x => x.campaign === id && x.group === group)
+      .map(_.update)
+      .update(Some(update))
+      .handleSingleUpdateError(MissingCampaign)
+      .map(_ => ())
+
+  }
+
+  def setPackage(id: Campaign.Id, pkgUuid: PackageId)
                 (implicit ec: ExecutionContext): DBIO[Unit] = {
     val dbIO = for {
       meta <- canEdit(id)
-      pkg <- Packages.find(meta.namespace, pkgId)
+      pkg <- Packages.find(meta.namespace, pkgUuid)
       _ <- byId(id)
              .map(_.packageUuid)
              .update(Some(pkg.uuid))

--- a/core/src/test/scala/org/genivi/sota/core/Generators.scala
+++ b/core/src/test/scala/org/genivi/sota/core/Generators.scala
@@ -121,9 +121,9 @@ trait Generators {
     name <- Gen.identifier
   } yield CreateCampaign(name)
 
-  val CampaignGroupsGen: Gen[CampaignGroups] = for {
-    groups <- Gen.nonEmptyContainerOf[List, GroupInfo.Name](GroupInfoGenerators.genGroupName)
-  } yield CampaignGroups(groups)
+  val SetCampaignGroupsGen: Gen[SetCampaignGroups] = for {
+    groups <- Gen.nonEmptyContainerOf[List, Uuid](Uuid.generate())
+  } yield SetCampaignGroups(groups)
 }
 
 object Generators extends Generators

--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -223,7 +223,7 @@ paths:
         description: The groups to add to campaign
         required: true
         schema: 
-          $ref: '#/definitions/CampaignGroups'
+          $ref: '#/definitions/SetCampaignGroups'
       responses:
         200:
           description: OK
@@ -811,7 +811,7 @@ definitions:
       groups:
         type: array
         items:
-          type: string
+          $ref: '#/definitions/CampaignGroup'
         description: An array of group names
       meta:
         $ref: '#/definitions/CampaignMeta'
@@ -840,14 +840,21 @@ definitions:
       name:
         type: string
         description: The name to give to the campaign
-  CampaignGroups:
+  CampaignGroup:
+    type: object
+    properties:
+      group:
+        $ref: '#/definitions/uuid'
+      updateRequest:
+        $ref: '#/definitions/uuid'
+  SetCampaignGroups:
     type: object
     properties:
       groups:
         type: array
         items:
-          type: string
-        description: The groups for the campaign
+          $ref: '#/definitions/uuid'
+        description: The uuids of the groups for the campaign
   SystemInfo:
     type: object
     description: |

--- a/external-resolver/src/main/resources/application.conf
+++ b/external-resolver/src/main/resources/application.conf
@@ -16,6 +16,7 @@ device_registry = {
   baseUri = "http://localhost:8083"
   baseUri = ${?DEVICE_REGISTRY_API_URI}
   devicesUri = "/api/v1/devices"
+  deviceGroupsUri = "/api/v1/device_groups"
 }
 
 server {

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -61,6 +61,7 @@ class Settings(val config: Config) {
 
   val deviceRegistryUri = Uri(config.getString("device_registry.baseUri"))
   val deviceRegistryApi = Uri(config.getString("device_registry.devicesUri"))
+  val deviceRegistryGroupApi = Uri(config.getString("device_registry.deviceGroupsUri"))
 }
 
 
@@ -84,7 +85,7 @@ object Boot extends App with Directives with BootMigrations {
   val namespaceDirective = NamespaceDirectives.fromConfig()
 
   val deviceRegistryClient = new DeviceRegistryClient(
-    settings.deviceRegistryUri, settings.deviceRegistryApi
+    settings.deviceRegistryUri, settings.deviceRegistryApi, settings.deviceRegistryGroupApi
   )
 
   val routes: Route =


### PR DESCRIPTION
Launching a campaign creates an updateRequest for every group associated with the campaign.

The CampaignGroups table have been changed for two reasons:
1) Groups are now referenced by uuid instead of names
2) We need to store the UpdateRequest if it exist for the group (it might be null in case the campaign is not launched)
This migration updates the primary key because of reason 1, I think I updated this correctly but please check.

I also updated the campaign code to use the common Uuid, instead of using a special Id type to be more consistent with the rest of the code base. 