### PR TITLE
[PRO-1392] Documentation for campaign had wrong endpoints

### DIFF
--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -124,7 +124,7 @@ paths:
             type: array
             items:
               type: string
-  /campaign:
+  /campaigns:
     get:
       description: 'List all campaigns'
       responses:


### PR DESCRIPTION
[PRO-1392] The /campaigns end-point was written in the documentation as /campaign.