### PR TITLE
[PRO-1623] add support for discarded attributes when grouping

### DIFF
--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/GroupsResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/GroupsResource.scala
@@ -53,7 +53,7 @@ class GroupsResource(namespaceExtractor: Directive1[Namespace])
   def updateMembershipsForGroup(ns: Namespace, groupId: Uuid, groupInfo: Json): Future[Int] = {
     val dbIO = for {
       matchingGroups <- list(ns).map(
-                          _.filter(r => JsonComparison.getCommonJson(groupInfo, r.systemInfo).equals(groupInfo))
+                          _.filter(r => JsonMatcher.compare(groupInfo, r.systemInfo)._1.equals(groupInfo))
                           .map(_.uuid))
       res            <- DBIO.sequence(matchingGroups.map { deviceId =>
                           GroupMemberRepository.addOrUpdateGroupMember(groupId, deviceId)
@@ -71,7 +71,7 @@ class GroupsResource(namespaceExtractor: Directive1[Namespace])
     val commonJsonDbIo = for {
       info1 <- findByUuid(request.device1)
       info2 <- findByUuid(request.device2)
-    } yield JsonComparison.getCommonJson(info1, info2)
+    } yield JsonMatcher.compare(info1, info2)._1
 
     onComplete(db.run(commonJsonDbIo)) {
       case Success(json) => json match {

--- a/device-registry/src/test/scala/org/genivi/sota/device_registry/JsonComparisonSpec.scala
+++ b/device-registry/src/test/scala/org/genivi/sota/device_registry/JsonComparisonSpec.scala
@@ -1,50 +1,56 @@
 package org.genivi.sota.device_registry
 
 import io.circe.Json
+import io.circe.parser._
 import org.scalatest.{FunSuite, Matchers}
 
-class JsonComparisonSpec extends FunSuite with Matchers {
+class JsonMatcherSpec extends FunSuite with Matchers {
 
-  val simpleJsonObj = Json.obj(("key", Json.fromString("value")))
-  val simpleJsonArray = Json.obj(("key", Json.fromString("value")))
-  val keyOnlyObj = Json.obj(("key", Json.Null))
-  val complexJsonObj = Json.fromFields(List(("key", Json.fromString("value")), ("type", Json.fromString("fish"))))
-  val complexNumericJsonObj = Json.fromFields(List(("key", Json.fromString("value")), ("type", Json.fromInt(5))))
-  val complexJsonArray =
-    Json.arr(Json.fromFields(List(("key", Json.fromString("value")), ("type", Json.fromString("fish")))))
-  val complexNumericJsonArray =
-    Json.arr(Json.fromFields(List(("key", Json.fromString("value")), ("type", Json.fromInt(5)))))
+  val simpleJsonObj           = parse(""" { "key": "value" }                     """).toOption.get
+  val keyOnlyObj              = parse(""" { "key": null }                        """).toOption.get
+  val complexJsonObj          = parse(""" { "key": "value", "type": "fish" }     """).toOption.get
+  val complexNumericJsonObj   = parse(""" { "key": "value", "type": 5 }          """).toOption.get
+  val complexJsonArray        = parse(""" [ { "key": "value", "type": "fish" } ] """).toOption.get
+  val complexNumericJsonArray = parse(""" [ { "key": "value", "type": 5 } ]      """).toOption.get
 
   test("json comparison of two empty sets returns empty json object") {
-    JsonComparison.getCommonJson(Json.Null, Json.Null) shouldEqual  Json.Null
+    JsonMatcher.compare(Json.Null, Json.Null)
+      .shouldEqual((Json.Null, Json.Null))
   }
 
   test("json comparison of two identical json objects returns same object") {
-    JsonComparison.getCommonJson(simpleJsonObj, simpleJsonObj) shouldEqual  simpleJsonObj
+    JsonMatcher.compare(simpleJsonObj, simpleJsonObj)
+      .shouldEqual((simpleJsonObj, Json.Null))
   }
 
   test("json comparison of two different json objects returns null") {
-    JsonComparison.getCommonJson(simpleJsonObj, keyOnlyObj) shouldEqual  Json.Null
+    JsonMatcher.compare(simpleJsonObj, keyOnlyObj)
+      .shouldEqual((Json.Null, keyOnlyObj))
   }
 
   test("json comparison of two similar json objects returns common json") {
-    JsonComparison.getCommonJson(simpleJsonObj, complexJsonObj) shouldEqual  simpleJsonObj
+    JsonMatcher.compare(simpleJsonObj, complexJsonObj)
+      .shouldEqual((simpleJsonObj, Json.obj("type" -> Json.Null)))
   }
 
   test("json comparison of two json objects with different value types returns common json") {
-    JsonComparison.getCommonJson(complexJsonObj, complexNumericJsonObj) shouldEqual simpleJsonObj
+    JsonMatcher.compare(complexJsonObj, complexNumericJsonObj)
+      .shouldEqual((simpleJsonObj, Json.obj("type" -> Json.Null)))
   }
 
-  test("json comparison of two empty json arrays returns null") {
-    JsonComparison.getCommonJson(Json.arr(Json.Null), Json.arr(Json.Null)) shouldEqual Json.arr(Json.Null)
+  test("json comparison of two empty json arrays returns an empty array") {
+    JsonMatcher.compare(Json.arr(), Json.arr())
+      .shouldEqual((Json.arr(), Json.Null))
   }
 
   test("json comparison of two simple json arrays returns common json") {
-    JsonComparison.getCommonJson(Json.arr(simpleJsonObj), Json.arr(simpleJsonObj)) shouldEqual Json.arr(simpleJsonObj)
+    JsonMatcher.compare(Json.arr(simpleJsonObj), Json.arr(simpleJsonObj))
+      .shouldEqual((Json.arr(simpleJsonObj), Json.Null))
   }
 
   test("json comparison of two json arrays with different value types returns common json") {
-    JsonComparison.getCommonJson(complexJsonArray, complexNumericJsonArray) shouldEqual Json.arr(simpleJsonObj)
+    JsonMatcher.compare(complexJsonArray, complexNumericJsonArray)
+      .shouldEqual((Json.arr(simpleJsonObj), Json.Null))
   }
 
 }


### PR DESCRIPTION
the discarded info is a json of the form

```
{
  "key1": {
    "key2": null,
    "key3": null
    },
  "key4": null
}
```

… where nodes denote common attrs with differing (object or array) children,
and leaves always have values `null` denoting differing values.