### PR TITLE
[PRO-1611] Pass namespace explicitly in headers when AUTH_PROTOCOL=none

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
@@ -26,8 +26,8 @@ trait DeviceRegistry {
     searchDevice(ns, Refined.unsafeApply(".*"))
 
   def createDevice
-  (device: DeviceT)
-  (implicit ec: ExecutionContext): Future[Uuid]
+    (device: DeviceT)
+    (implicit ec: ExecutionContext): Future[Uuid]
 
   def fetchDevice
     (uuid: Uuid)

--- a/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
+++ b/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
@@ -93,7 +93,7 @@ class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri, deviceGroupsUri: Uri)
     execHttp[Unit](HttpRequest(method = POST, uri = baseUri.withPath(devicesUri.path / uuid.show / "ping")))
 
   override def updateSystemInfo(uuid: Uuid, json: Json)
-                              (implicit ec: ExecutionContext): Future[Unit] =
+                               (implicit ec: ExecutionContext): Future[Unit] =
     execHttp[Unit](HttpRequest(method = PUT, uri = baseUri.withPath(devicesUri.path / uuid.show / "system_info"),
       entity = HttpEntity(ContentTypes.`application/json`, json.noSpaces)))
 

--- a/common/src/main/scala/org/genivi/sota/http/NamespaceDirectives.scala
+++ b/common/src/main/scala/org/genivi/sota/http/NamespaceDirectives.scala
@@ -1,5 +1,7 @@
 package org.genivi.sota.http
 
+import akka.http.scaladsl.model.HttpHeader
+import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.server.directives.BasicDirectives
 import com.advancedtelematic.jwt.JsonWebToken
@@ -10,16 +12,28 @@ import org.slf4j.LoggerFactory
 import scala.util.Try
 
 object NamespaceDirectives {
+  import akka.http.scaladsl.server.Directives._
+
   lazy val logger = LoggerFactory.getLogger(this.getClass)
 
   import eu.timepit.refined.refineV
+
+  val NAMESPACE = "x-ats-namespace"
+
+  def nsHeader(ns: Namespace): HttpHeader = RawHeader(NAMESPACE, ns.get)
 
   def configNamespace(config: Config): Namespace = {
     Namespace( Try(config.getString("core.defaultNs")).getOrElse("default"))
   }
 
-  lazy val defaultNamespaceExtractor: Directive1[Namespace] =
-    BasicDirectives.provide(configNamespace(ConfigFactory.load()))
+  lazy val defaultNamespaceExtractor: Directive1[Namespace] = {
+    extractRequest.flatMap { req =>
+      req.headers.find(_.is(NAMESPACE)).map(_.value()) match {
+        case Some(ns) => provide(Namespace(ns))
+        case None => provide(configNamespace(ConfigFactory.load()))
+      }
+    }
+  }
 
   def fromConfig(): Directive1[Namespace] = {
     val config = ConfigFactory.load().getString("auth.protocol")

--- a/web-server/app/assets/javascripts/handlers/vehicles.js
+++ b/web-server/app/assets/javascripts/handlers/vehicles.js
@@ -31,16 +31,16 @@ define(function(require) {
             createVehicle(payload);
           break;
           case 'search-vehicles-by-regex':
-            var query = payload.regex ? '&regex=' + payload.regex : '';
+            var query = payload.regex ? '?regex=' + payload.regex : '';
 
-            sendRequest.doGet('/api/v1/devices?namespace=default' + query)
+            sendRequest.doGet('/api/v1/devices' + query)
               .success(function(vehicles) {
                 db.searchableVehicles.reset(vehicles);
               });
           break;
           case 'fetch-affected-vins':
-            var affectedVinsUrl = '/api/v1/resolver/resolve?namespace=default' +
-            '&package_name=' + payload.name + '&package_version=' + payload.version;
+            var affectedVinsUrl = '/api/v1/resolver/resolve' +
+            '?package_name=' + payload.name + '&package_version=' + payload.version;
 
             sendRequest.doGet(affectedVinsUrl)
               .success(function(vehicles) {

--- a/web-server/conf/routes
+++ b/web-server/conf/routes
@@ -12,6 +12,8 @@ GET     /webjars/*file                          controllers.WebJarAssets.at(file
 GET     /login                                  org.genivi.webserver.controllers.Application.login
 GET     /logout                                 org.genivi.webserver.controllers.Application.logout
 POST    /authenticate                           org.genivi.webserver.controllers.Application.authenticate
+GET     /api/v1/devices                         org.genivi.webserver.controllers.Application.listDeviceAttributes
+GET     /api/v1/resolver/resolve                org.genivi.webserver.controllers.Application.resolver
 
 GET     /api/v1/*path                           org.genivi.webserver.controllers.Application.apiProxy(path: String)
 PUT     /api/v1/*path                           org.genivi.webserver.controllers.Application.apiProxy(path: String)


### PR DESCRIPTION
If AUTH_PROTOCOL=none then namespaceExtractor will now return the namespace in the header (x-ats-namespace) if it exists otherwise return the default one.

GENIVI webserver uses loggedIn.id as a namespace and sets the header on all request. Two endpoints that got the namespace via a queryparameter are now proxied via webserver to add the correct namespace.