### PR TITLE
Add valid default value for json column

### DIFF
--- a/device-registry/src/main/resources/db/migration/V11__discarded_attrs_default_value.sql
+++ b/device-registry/src/main/resources/db/migration/V11__discarded_attrs_default_value.sql
@@ -1,0 +1,8 @@
+UPDATE DeviceGroup
+SET discarded_attrs="null"
+WHERE discarded_attrs IS NULL;
+
+ALTER TABLE DeviceGroup
+change discarded_attrs discarded_attrs LONGTEXT NOT NULL;
+ALTER TABLE DeviceGroup
+ALTER discarded_attrs SET DEFAULT "null";


### PR DESCRIPTION
 - PRO-1651
 - This commit adds a default, non-null, value for the discarded_attrs
   column in the device registry db. This is to fix 500 errors we got
   due to null values in this column which are unexpected by slick as
   the column does not have an Option type.