### PR TITLE
[PRO-1669] campaign launch should take some metadata

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
@@ -5,6 +5,7 @@
 package org.genivi.sota.core.data
 
 import cats.Show
+import cats.data.Xor
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
 import io.circe._
@@ -34,6 +35,23 @@ object Campaign {
   case class CreateCampaign(name: String)
   case class SetCampaignGroups(groups: Seq[Uuid])
   case class CampaignGroup(group: Uuid, updateRequest: Option[Uuid])
+
+  case class LaunchCampaign(
+    startDate: Instant,
+    endDate: Instant,
+    priority: Option[Int],
+    signature: Option[String],
+    description: Option[String],
+    requestConfirmation: Option[Boolean]
+  ) {
+    def isValid(): String Xor Unit = {
+      if(startDate.isBefore(endDate)) {
+        Xor.Right(())
+      } else {
+        Xor.Left("The LaunchCampaign object is not valid because the start date is not before end date.")
+      }
+    }
+  }
 
   final case class Id(underlying: Uuid)
 

--- a/core/src/test/scala/org/genivi/sota/core/Generators.scala
+++ b/core/src/test/scala/org/genivi/sota/core/Generators.scala
@@ -124,6 +124,15 @@ trait Generators {
   val SetCampaignGroupsGen: Gen[SetCampaignGroups] = for {
     groups <- Gen.nonEmptyContainerOf[List, Uuid](Uuid.generate())
   } yield SetCampaignGroups(groups)
+
+  val LaunchCampaignGen: Gen[LaunchCampaign] = for {
+    startDate   <- Gen.choose(10, 100).map( d => Instant.now.plus(Duration.ofDays(d)) )
+    endDate <- Gen.choose(10, 100).map( x => startDate.plus(Duration.ofDays(x)) )
+    prio         <- Gen.option(Gen.choose(1, 10))
+    sig          <- Gen.option(Gen.alphaStr)
+    desc         <- Gen.option(Gen.alphaStr)
+    reqConfirm   <- Gen.option(arbitrary[Boolean])
+  } yield LaunchCampaign(startDate, endDate, prio, sig, desc, reqConfirm)
 }
 
 object Generators extends Generators

--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -236,6 +236,11 @@ paths:
         description: The campaign uuid to launch
         required: true
         type: string
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/LaunchCampaign'
       responses:
         200:
           description: OK
@@ -863,6 +868,29 @@ definitions:
         $ref: '#/definitions/uuid'
       updateRequest:
         $ref: '#/definitions/uuid'
+  LaunchCampaign:
+    type: object
+    properties:
+      startDate:
+        type: string
+        format: dateTime
+        description: The time for the start of the campaign
+      endDate:
+        type: string
+        format: dateTime
+        description: The time for the end of the campaign
+      priority:
+        type: integer
+        description: Optional pritority for the launch.
+      signature:
+        type: string
+        description: Optional signature for the launch.
+      description:
+        type: string
+        description: Optional description of the launch.
+      requestConfirmation:
+        type: boolean
+        description: True if client should wait for user confirmation before installing, defaults to false.
   SetCampaignGroups:
     type: object
     properties:


### PR DESCRIPTION
The launch end-point needs some meta-data so that we can overwrite the default for the updateRequest that are created when launching.