### PR TITLE
[PRO-1648] Add more id-nr in system_info

### DIFF
--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
@@ -26,25 +26,6 @@ class SystemInfoResource(deviceNamespaceAuthorizer: Directive1[Uuid])
 
   val logger = LoggerFactory.getLogger(this.getClass)
 
-  def updateGroupMembershipsForDevice(deviceUuid: Uuid, data: Json): Future[Int] = {
-    val dbIO = for {
-      _          <- GroupMemberRepository.removeDeviceFromAllGroups(deviceUuid)
-      ns         <- DeviceRepository.deviceNamespace(deviceUuid)
-      groupInfos <- GroupInfoRepository.list(ns)
-      groups     =  groupInfos
-                      .filter(r => JsonMatcher.compare(data, r.groupInfo)._1.equals(r.groupInfo))
-                      .map(_.id)
-      res        <- DBIO.sequence(groups.map { groupId =>
-                      GroupMemberRepository.addGroupMember(groupId, deviceUuid)
-                    })
-    } yield res
-
-    val f = db.run(dbIO.transactionally).map(_.sum)
-    f.onFailure { case e =>
-      logger.error(s"Got error whilst updating group id $deviceUuid: ${e.toString}")
-    }
-    f
-  }
 
   def fetchSystemInfo(uuid: Uuid): Route = {
     val comp = db.run(SystemInfoRepository.findByUuid(uuid)).recover{
@@ -56,7 +37,7 @@ class SystemInfoResource(deviceNamespaceAuthorizer: Directive1[Uuid])
   def createSystemInfo(uuid: Uuid, data: Json): Route = {
     val f = db.run(SystemInfoRepository.create(uuid, data))
     f.onSuccess { case _ =>
-      updateGroupMembershipsForDevice(uuid, data)
+      UpdateMemberships.forDevice(uuid, data)
     }
     complete(Created -> f)
   }
@@ -64,7 +45,7 @@ class SystemInfoResource(deviceNamespaceAuthorizer: Directive1[Uuid])
   def updateSystemInfo(uuid: Uuid, data: Json): Route = {
     val f = db.run(SystemInfoRepository.update(uuid, data))
     f.onSuccess { case _ =>
-      updateGroupMembershipsForDevice(uuid, data)
+      UpdateMemberships.forDevice(uuid, data)
     }
     complete(f)
   }

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/UpdateMemberships.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/UpdateMemberships.scala
@@ -1,0 +1,80 @@
+package org.genivi.sota.device_registry
+
+import io.circe.Json
+import org.genivi.sota.data.{Namespace, Uuid}
+import org.genivi.sota.device_registry.common.CreateGroupRequest
+import org.genivi.sota.device_registry.db._
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+import slick.driver.MySQLDriver.api._
+
+object UpdateMemberships {
+  import JsonMatcher._
+  import SystemInfoRepository._
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  def forGroup(ns: Namespace,
+               groupId: Uuid,
+               matching: Json,
+               discarded: Json)
+              (implicit ec: ExecutionContext, db: Database): Future[Unit] = {
+    val dbIO = list(ns).flatMap { allDevices =>
+      DBIO.seq(allDevices.collect {
+        case info
+          if compare(disregard(removeIdNrs(info.systemInfo), discarded), matching)
+            .equals((matching, Json.Null)) =>
+          GroupMemberRepository.addOrUpdateGroupMember(groupId, info.uuid)
+      } :_*)
+    }
+
+    db.run(dbIO.transactionally).andThen {
+      case Failure(ex) =>
+        logger.error(s"Got error whilst updating group id $groupId", ex)
+    }
+
+  }
+
+  def forDevice(deviceUuid: Uuid, data: Json)
+               (implicit ec: ExecutionContext, db: Database): Future[Unit] = {
+    val dbIO = for {
+      _          <- GroupMemberRepository.removeDeviceFromAllGroups(deviceUuid)
+      ns         <- DeviceRepository.deviceNamespace(deviceUuid)
+      groupInfos <- GroupInfoRepository.list(ns)
+      actions    =  groupInfos.collect {
+        case grp if JsonMatcher.compare(data, grp.groupInfo)._1.equals(grp.groupInfo) =>
+          GroupMemberRepository.addGroupMember(grp.id, deviceUuid)
+      }
+      _          <- DBIO.seq(actions :_*)
+    } yield ()
+
+    db.run(dbIO.transactionally).andThen {
+      case Failure(e) =>
+        logger.error(s"Got error whilst updating group id $deviceUuid: ${e.toString}")
+    }
+  }
+
+
+  def createGroupFromDevices(request: CreateGroupRequest, namespace: Namespace)
+                            (implicit ec: ExecutionContext, db: Database): Future[Uuid] = {
+    val commonJsonDbIo = for {
+      info1 <- findByUuid(request.device1).map(removeIdNrs)
+      info2 <- findByUuid(request.device2).map(removeIdNrs)
+    } yield compare(info1, info2)
+
+    db.run(commonJsonDbIo).flatMap { json =>
+      json match {
+        case (Json.Null, _) =>
+          Future.failed(new Throwable("Devices have no common attributes to form a group"))
+        case (matching, discarded) =>
+          val groupId = Uuid.generate()
+          db.run(GroupInfoRepository.create(groupId, request.groupName, namespace, matching, discarded)).andThen {
+
+            case Success(_) => forGroup(namespace, groupId, matching, discarded)
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I also changed so we add the id-nr when fetching rather than when
inserting into the database. The idea with doing it before inserting
was that it would not perform this computation all the time. But this
interferes with group_info, since that shouldn't consider id-nr.