### PR TITLE
[PRO-1714] Remove namespace as query parameter to device-registry/resolver

### DIFF
--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/DevicesResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/DevicesResource.scala
@@ -98,6 +98,7 @@ class DevicesResource(namespaceExtractor: Directive1[Namespace],
     pathPrefix("devices") {
       namespaceExtractor { ns =>
         (post & entity(as[DeviceT]) & pathEndOrSingleSlash) { device => createDevice(ns, device) } ~
+        (get & pathEnd) { searchDevice(ns) } ~
         extractUuid { uuid =>
           //TODO: PRO-1666, use deviceNamespaceAuthorizer for this block, instead of extractUuid, once support has been
           // added into core
@@ -120,9 +121,6 @@ class DevicesResource(namespaceExtractor: Directive1[Namespace],
         (get & path("groups") & pathEnd) {
           getGroupsForDevice(uuid)
         }
-      } ~
-      (get & pathEnd & parameter('namespace.as[Namespace])) { ns =>
-        searchDevice(ns)
       }
     }
 

--- a/docs/swagger/sota-device_registry.yml
+++ b/docs/swagger/sota-device_registry.yml
@@ -18,12 +18,7 @@ produces:
 paths:
   /devices:
     get:
-      description: 'Get a list of all the devices in a particular namespace in the device registry.'
-      parameters:
-      - name: namespace
-        in: query
-        required: true
-        type: string
+      description: 'Get a list of all the devices in the namespace in the device registry.'
       responses:
         200:
           description: OK
@@ -34,10 +29,6 @@ paths:
     post:
       description: 'Register a new device with a name and an ID, get back its UUID'
       parameters:
-      - name: namespace
-        in: query
-        required: true
-        type: string
       - name: DeviceT
         in: body
         required: true

--- a/docs/swagger/sota-resolver.yml
+++ b/docs/swagger/sota-resolver.yml
@@ -291,10 +291,6 @@ paths:
     get:
       description: Resolve a package into a list of vehicles it should be installed on.
       parameters:
-      - name: namespace
-        in: query
-        required: true
-        type: string
       - name: package_name
         in: query
         required: true

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/packages/PackageDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/packages/PackageDirectives.scala
@@ -91,7 +91,7 @@ class PackageDirectives(namespaceExtractor: Directive1[Namespace], deviceRegistr
    */
   def route: Route = ErrorHandler.handleErrors {
     pathPrefix("packages") {
-      (path("affected") & parameter("namespace".as[Namespace])) { ns =>
+      (path("affected") & namespaceExtractor) { ns =>
         post { findAffected(ns) }
       } ~
       (get & path("filter")) {

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/resolve/ResolveDirectives.scala
@@ -46,7 +46,7 @@ class ResolveDirectives(namespaceExtractor: Directive1[Namespace],
     (get &
       encodeResponse &
       pathPrefix("resolve") &
-      parameter('namespace.as[Namespace]) & refinedPackageIdParams) { (ns, id) =>
+      namespaceExtractor & refinedPackageIdParams) { (ns, id) =>
       resolvePackage(ns, id)
     }
   }


### PR DESCRIPTION
PRO-1714

Remove all namespace query parameters, and use the namespaceextractor instead. This means that core and resolver needs to send the namespace via the header instead.