### PR TITLE
[PRO-1782] Allow underscores in package names.

### DIFF
--- a/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
+++ b/common-data/src/main/scala/org/genivi/sota/data/PackageId.scala
@@ -42,7 +42,7 @@ object PackageId {
   implicit val validPackageName: Validate.Plain[String, ValidName] =
     Validate.fromPredicate(
       s => s.length > 0 && s.length <= 100
-        && s.forall(c => c.isLetter || c.isDigit || List('-', '+', '.').contains(c)),
+        && s.forall(c => c.isLetter || c.isDigit || List('-', '+', '.', '_').contains(c)),
       s => s"$s: isn't a valid package name (between 1 and 100 character long alpha numeric string)",
       ValidName()
     )


### PR DESCRIPTION
Resolves [PRO-1782](https://advancedtelematic.atlassian.net/browse/PRO-1782)