### PR TITLE
[PRO-1775] enable namespace checking in device registry

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
@@ -25,12 +25,8 @@ trait DeviceRegistry {
   (implicit ec: ExecutionContext): Future[Seq[Device]] =
     searchDevice(ns, Refined.unsafeApply(".*"))
 
-  def createDevice
-    (device: DeviceT)
-    (implicit ec: ExecutionContext): Future[Uuid]
-
   def fetchDevice
-    (uuid: Uuid)
+    (namespace: Namespace, uuid: Uuid)
     (implicit ec: ExecutionContext): Future[Device]
 
   def fetchMyDevice
@@ -38,7 +34,7 @@ trait DeviceRegistry {
     (implicit ec: ExecutionContext): Future[Device]
 
   def fetchDevicesInGroup
-    (uuid: Uuid)
+    (namespace: Namespace, uuid: Uuid)
     (implicit ec: ExecutionContext): Future[Seq[Uuid]]
 
   def fetchGroup
@@ -49,14 +45,6 @@ trait DeviceRegistry {
     (ns: Namespace, deviceId: DeviceId)
     (implicit ec: ExecutionContext): Future[Device]
 
-  def updateDevice
-    (uuid: Uuid, device: DeviceT)
-    (implicit ec: ExecutionContext): Future[Unit]
-
-  def deleteDevice
-    (uuid: Uuid)
-    (implicit ec: ExecutionContext): Future[Unit]
-
   def updateLastSeen
     (uuid: Uuid, seenAt: Instant = Instant.now)
     (implicit ec: ExecutionContext): Future[Unit]
@@ -64,8 +52,4 @@ trait DeviceRegistry {
   def updateSystemInfo
     (uuid: Uuid, json: Json)
     (implicit ec: ExecutionContext): Future[Unit]
-
-  def getSystemInfo
-    (uuid: Uuid)
-    (implicit ec: ExecutionContext): Future[Json]
 }

--- a/core/src/main/scala/org/genivi/sota/core/DeviceUpdatesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DeviceUpdatesResource.scala
@@ -236,14 +236,10 @@ class DeviceUpdatesResource(db: Database,
   def authDeviceNamespace(deviceId: Uuid) : Directive1[Namespace] =
     authNamespace flatMap { ns =>
       import scala.util.{Success, Failure}
-      val f = deviceRegistry.fetchDevice(deviceId)
+      val f = deviceRegistry.fetchDevice(ns, deviceId)
       onComplete(f) flatMap {
         case Success(device) =>
-          if (device.namespace == ns) {
             provide(ns)
-          } else {
-            reject(AuthorizationFailedRejection)
-          }
         case Failure(t) => reject(failNamespaceRejection("Cannot validate namespace"))
       }
     }

--- a/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
@@ -111,13 +111,7 @@ class DevicesResource(db: Database, client: ConnectivityClient,
 
   def getDeviceWithStatus(ns: Namespace, uuid: Uuid): Route = {
     parameters(('status.?(false))) { (includeStatus: Boolean) =>
-      val devices = deviceRegistry.fetchDevice(uuid).flatMap { device =>
-        if (device.namespace == ns) {
-          Future.successful(Seq(device))
-        } else {
-          Future.failed(MissingEntity(classOf[DeviceSearchResult]))
-        }
-      }.recoverWith {
+      val devices = deviceRegistry.fetchDevice(ns, uuid).map(Seq(_)).recoverWith {
         case e => Future.failed(MissingEntity(classOf[DeviceSearchResult]))
       }
       val devicesWithStatus = if (includeStatus) {

--- a/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
@@ -156,7 +156,7 @@ class DeviceUpdatesResourceSpec extends FunSuite
       status shouldBe StatusCodes.OK
       responseAs[List[UUID]] should be(empty)
 
-      val device = fakeDeviceRegistry.fetchDevice(deviceUuid).futureValue
+      val device = fakeDeviceRegistry.fetchMyDevice(deviceUuid).futureValue
       device.lastSeen shouldBe defined
       device.lastSeen.get.isAfter(now) shouldBe true
     }
@@ -540,7 +540,7 @@ class DeviceUpdatesResourceSpec extends FunSuite
       status shouldBe StatusCodes.OK
       responseAs[List[UUID]] should be(empty)
 
-      val device = fakeDeviceRegistry.fetchDevice(deviceUuid).futureValue
+      val device = fakeDeviceRegistry.fetchMyDevice(deviceUuid).futureValue
       device.lastSeen shouldBe defined
       device.lastSeen.get.isAfter(now) shouldBe true
     }

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/DevicesResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/DevicesResource.scala
@@ -101,9 +101,7 @@ class DevicesResource(namespaceExtractor: Directive1[Namespace],
       namespaceExtractor { ns =>
         (post & entity(as[DeviceT]) & pathEndOrSingleSlash) { device => createDevice(ns, device) } ~
         (get & pathEnd) { searchDevice(ns) } ~
-        extractUuid { uuid =>
-          //TODO: PRO-1666, use deviceNamespaceAuthorizer for this block, instead of extractUuid, once support has been
-          // added into core
+        deviceNamespaceAuthorizer { uuid =>
           (put & entity(as[DeviceT]) & pathEnd) { device =>
             updateDevice(ns, uuid, device)
           } ~
@@ -112,8 +110,7 @@ class DevicesResource(namespaceExtractor: Directive1[Namespace],
           }
         }
       } ~
-      extractUuid { uuid =>
-        //TODO: PRO-1666, use deviceNamespaceAuthorizer once support has been added into core
+      deviceNamespaceAuthorizer { uuid =>
         (post & path("ping")) {
           updateLastSeen(uuid)
         } ~

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/GroupsResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/GroupsResource.scala
@@ -100,16 +100,14 @@ class GroupsResource(namespaceExtractor: Directive1[Namespace], deviceNamespaceA
           listGroups(ns)
         }
       } ~
-      (get & extractUuid & path("devices") ) { groupId =>
-        //TODO: PRO-1666, move this back into the extractGroupId block once core supports namespaces
+      (get & extractGroupId & path("devices") ) { groupId =>
         getDevicesInGroup(groupId)
       } ~
-      extractUuid { groupId =>
-        //TODO: PRO-1666, use extractGroupId/deviceNamespaceAuthorizer once support has been added to core
-        (post & pathPrefix("devices") & extractUuid) { deviceId =>
+      extractGroupId { groupId =>
+        (post & pathPrefix("devices") & deviceNamespaceAuthorizer) { deviceId =>
           addDeviceToGroup(groupId, deviceId)
         } ~
-        (delete & pathPrefix("devices") & extractUuid) { deviceId =>
+        (delete & pathPrefix("devices") & deviceNamespaceAuthorizer) { deviceId =>
           removeDeviceFromGroup(groupId, deviceId)
         } ~
         (put & path("rename") & parameter('groupName.as[Name])) { groupName =>

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
@@ -49,8 +49,7 @@ class SystemInfoResource(authDirective: AuthScope => Directive0, deviceNamespace
 
   def api: Route =
     pathPrefix("devices") {
-      extractUuid { uuid =>
-        //TODO: PRO-1666, use deviceNamespaceAuthorizer once support has been added to core
+      deviceNamespaceAuthorizer { uuid =>
         (get & path("system_info")) {
           fetchSystemInfo(uuid)
         } ~


### PR DESCRIPTION
All routes in the device registry should check that resources belongs to the namespace, (the exception is in mydevice that checks the token). This means that DeviceRegistryClient needs to send the namespace for all calls that doesn't go to mydevice route.

At the same time I removed methods from DeviceRegistryClient that are not used by any service (some were only used by tests and are only kept for the fake device registry).

Also note that the fetchMyDevice method goes via mydevice route, but since AUTH_PROTOCOL=none for the device registry we don't yet need to send a token. Also it is convenient to use in tests.