### PR TITLE
[PRO-1783] Resolver should check resources namespace

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/common/Errors.scala
+++ b/common-client/src/main/scala/org/genivi/sota/common/Errors.scala
@@ -4,6 +4,8 @@
  */
 package org.genivi.sota.device_registry.common
 
+import org.genivi.sota.http.Errors.RawError
+
 object Errors {
   import akka.http.scaladsl.model.StatusCodes
   import akka.http.scaladsl.server.Directives.complete
@@ -17,17 +19,7 @@ object Errors {
     val ConflictingDeviceId = ErrorCode("conflicting_device_id")
   }
 
-  case object MissingDevice extends Throwable with NoStackTrace
-  case object ConflictingDeviceId extends Throwable with NoStackTrace
-
-  val onMissingDevice: PF = {
-    case Errors.MissingDevice =>
-      complete(StatusCodes.NotFound -> ErrorRepresentation(Codes.MissingDevice, "Device doesn't exist"))
-  }
-
-  val onConflictingDeviceId: PF = {
-    case Errors.ConflictingDeviceId =>
-      complete(StatusCodes.Conflict -> ErrorRepresentation(Codes.ConflictingDeviceId, "deviceId is already in use"))
-  }
+  val MissingDevice = RawError(Codes.MissingDevice, StatusCodes.NotFound, "Device doesn't exist")
+  val ConflictingDeviceId = RawError(Codes.ConflictingDeviceId, StatusCodes.Conflict, "deviceId is already in use")
 
 }

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentDirectives.scala
@@ -32,7 +32,7 @@ class ComponentDirectives(namespaceExtractor: Directive1[Namespace])
 
   def searchComponent(ns: Namespace): Route =
     parameter('regex.as[String Refined Regex].?) { re =>
-      val query = re.fold(ComponentRepository.list)(re => ComponentRepository.searchByRegex(ns, re))
+      val query = re.fold(ComponentRepository.list(ns))(re => ComponentRepository.searchByRegex(ns, re))
       complete(db.run(query))
     }
 

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/components/ComponentRepository.scala
@@ -81,8 +81,8 @@ object ComponentRepository {
       .headOption
       .failIfNone(Errors.MissingComponent)
 
-  def list: DBIO[Seq[Component]] =
-    components.result
+  def list(namespace: Namespace): DBIO[Seq[Component]] =
+    components.filter(_.namespace === namespace).result
 
   def searchByRegex(namespace: Namespace, re: Refined[String, Regex]): DBIO[Seq[Component]] =
     components.filter(i => i.namespace === namespace && regex(i.partNumber, re.get)).result

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/PackageFilterRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/PackageFilterRepository.scala
@@ -50,10 +50,12 @@ object PackageFilterRepository {
     *
     * @return     A DBIO[Seq[PackageFilter]] for the package filters in the table
    */
-  def list: DBIO[Seq[(PackageFilter, PackageId)]] =
-  packageFilters.join(PackageRepository.packages).on(_.packageUuid === _.uuid)
-    .map { case (filter, pkg) => (filter, LiftedPackageId(pkg.name, pkg.version)) }
-    .result
+  def list(namespace: Namespace): DBIO[Seq[(PackageFilter, PackageId)]] =
+    packageFilters.filter(_.namespace === namespace)
+      .join(PackageRepository.packages.filter(_.namespace === namespace))
+      .on(_.packageUuid === _.uuid)
+      .map { case (filter, pkg) => (filter, LiftedPackageId(pkg.name, pkg.version)) }
+      .result
 
   def addPackageFilter(namespace: Namespace, packageId: PackageId, name: Filter.Name)
                       (implicit db: Database, ec: ExecutionContext): DBIO[PackageFilter] = {

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/PackageRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/PackageRepository.scala
@@ -81,8 +81,8 @@ object PackageRepository {
  *
    * @return     A DBIO[Seq[Package]] for the packages in the table
    */
-  def list: DBIO[Seq[Package]] =
-    packages.result
+  def list(namespace: Namespace): DBIO[Seq[Package]] =
+    packages.filter(_.namespace === namespace).result
 
   /**
    * Checks to see if a package exists in the database

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/devices/DeviceDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/devices/DeviceDirectives.scala
@@ -13,7 +13,10 @@ import eu.timepit.refined.string.Regex
 import io.circe.generic.auto._
 import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.data.{Namespace, PackageId, Uuid}
+import org.genivi.sota.device_registry.common.{Errors => DeviceRegistryErrors}
+import org.genivi.sota.http.AuthDirectives.AuthScope
 import org.genivi.sota.http.ErrorHandler
+import org.genivi.sota.http.UuidDirectives.extractUuid
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.genivi.sota.marshalling.RefinedMarshallingSupport._
 import org.genivi.sota.resolver.common.RefinementDirectives.{refinedPackageId, refinedPartNumber}
@@ -24,7 +27,7 @@ import org.genivi.sota.rest.Validation._
 import slick.driver.MySQLDriver.api._
 
 import scala.concurrent.{ExecutionContext, Future}
-
+import scala.util.{Success, Failure}
 
 /**
  * API routes for everything related to vehicles: creation, deletion, and package and component association.
@@ -32,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * @see {@linktourl http://advancedtelematic.github.io/rvi_sota_server/dev/api.html}
  */
 class DeviceDirectives(namespaceExtractor: Directive1[Namespace],
+                       authDirective: AuthScope => Directive0,
                        deviceRegistry: DeviceRegistry)
                       (implicit system: ActorSystem,
                         db: Database,
@@ -40,7 +44,13 @@ class DeviceDirectives(namespaceExtractor: Directive1[Namespace],
 
   import Directives._
 
-  val extractUuid: Directive1[Uuid] = refined[Uuid.Valid](Slash ~ Segment).map(Uuid(_))
+  def extractDeviceUuid(ns: Namespace): Directive1[Uuid] = extractUuid.flatMap { deviceId =>
+    onComplete(deviceRegistry.fetchDevice(ns, deviceId)).flatMap {
+      case Success(_) => provide(deviceId)
+      case Failure(DeviceRegistryErrors.MissingDevice) => complete(DeviceRegistryErrors.MissingDevice)
+      case Failure(t) => reject(AuthorizationFailedRejection)
+    }
+  }
 
   def searchDevices(ns: Namespace): Route =
     parameters(('regex.as[String Refined Regex].?,
@@ -111,8 +121,11 @@ class DeviceDirectives(namespaceExtractor: Directive1[Namespace],
           uninstallPackage(ns, device, pkgId)
         }
       }
-    } ~
-    (path("packages") & put) {
+    }
+  }
+
+  def packagesApi: Route = extractUuid { device =>
+    (path("packages") & put & authDirective(s"ota-core.{device.show}.write")) {
       updateInstalledSoftware(device)
     }
   }
@@ -151,11 +164,12 @@ class DeviceDirectives(namespaceExtractor: Directive1[Namespace],
   def deviceApi: Route =
     pathPrefix("devices") {
       namespaceExtractor { ns =>
-        (get & pathEnd) { searchDevices(ns) }
-      } ~
-      extractUuid { device =>
-        packageApi(device) ~
+        (get & pathEnd) { searchDevices(ns) } ~
+        extractDeviceUuid(ns) { device =>
+          packageApi(device) ~
           componentApi(device)
+        } ~
+        packagesApi
       }
     }
 

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/FilterDirectives.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/FilterDirectives.scala
@@ -35,7 +35,7 @@ class FilterDirectives(namespaceExtractor: Directive1[Namespace])
 
   def searchFilter(ns: Namespace): Route =
     parameter('regex.as[String Refined Regex].?) { re =>
-      val query = re.fold(FilterRepository.list)(re => FilterRepository.searchByRegex(ns, re))
+      val query = re.fold(FilterRepository.list(ns))(re => FilterRepository.searchByRegex(ns, re))
       complete(db.run(query))
     }
 

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/FilterRepository.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/filters/FilterRepository.scala
@@ -66,8 +66,8 @@ object FilterRepository {
       _ <- FilterRepository.delete(namespace, name)
     } yield ()
 
-  def list: DBIO[Seq[Filter]] =
-    filters.result
+  def list(namespace: Namespace): DBIO[Seq[Filter]] =
+    filters.filter(_.namespace === namespace).result
 
   def searchByRegex(namespace: Namespace, re: Refined[String, Regex]): DBIO[Seq[Filter]] =
     filters.filter(filter => filter.namespace === namespace && regex(filter.name, re.get)).result

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/DevicesResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/DevicesResourceSpec.scala
@@ -166,6 +166,8 @@ class DevicesResourceWordSpec extends ResourceWordSpec with Namespaces {
 
   val uuid = Uuid(Refined.unsafeApply("1f22860a-3ea2-491f-9042-37c98c2d51cd"))
 
+  deviceRegistry.addDevice(Device(Namespaces.defaultNs, uuid, DeviceName("name")))
+
   "Vin resource" should {
     "install a package on a VIN on PUT request to /vehicles/:vin/package/:packageName/:packageVersion" in {
       addPackageOK("apa", "1.0.1", None, None)

--- a/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ResourceSpec.scala
+++ b/external-resolver/src/test/scala/org/genivi/sota/resolver/test/ResourceSpec.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.genivi.sota.core.{DatabaseSpec, FakeDeviceRegistry}
 import org.genivi.sota.data.Device.DeviceName
 import org.genivi.sota.data.{Device, Namespaces, Uuid}
-import org.genivi.sota.http.NamespaceDirectives
+import org.genivi.sota.http.{AuthDirectives, NamespaceDirectives}
 import org.genivi.sota.resolver.Routing
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterAll, PropSpec, Suite, WordSpec}
@@ -40,7 +40,9 @@ trait ResourceSpec extends
 
   // Route
   lazy implicit val route: Route =
-    new Routing(NamespaceDirectives.defaultNamespaceExtractor, deviceRegistry).route ~
+    new Routing(NamespaceDirectives.defaultNamespaceExtractor,
+                AuthDirectives.allowAll,
+                deviceRegistry).route ~
     new FakeDeviceRegistryRoutes(deviceRegistry).route
 }
 


### PR DESCRIPTION
So checking that resources belong to the proper namespace was slightly more annoying than for device registry since the checking was done almost everywhere, but it is done in the database. So I had a fun Friday going through every end-point in the resolver one by one, looking what method they call (recursively) and see if things were checked to be in the proper namespace.

I can't guarantee that I found everything, but I think I got most of them. But I don't want to have a massive rewrite of all of the resovler to the checking up-front as we do elsewhere.

Anyway, notice that one route devices/{:uuid}/packages now checks token since this is another route that comes from a device. Since there is only a device that will call it I did not create a new mydevice route for it.