### PR TITLE
When blacklisting packages, to not change state for UpdateSpecs already installed.

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
@@ -9,6 +9,7 @@ import java.time.Instant
 import java.util.UUID
 
 import org.genivi.sota.core.db.Packages.{LiftedPackageId, LiftedPackageShape}
+import org.genivi.sota.core.db.UpdateSpecs.{UpdateSpecRow, UpdateSpecTable}
 import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.genivi.sota.http.Errors
 import shapeless._
@@ -109,9 +110,10 @@ object InstallHistories {
     log(spec.device, spec.request.id, spec.request.packageUuid, success)
   }
 
-  protected [db] def logAll(updateRequests: Query[Rep[UUID], UUID, Seq], success: Boolean): DBIO[Int] = {
+  protected [db] def logAll(updateSpecQuery: Query[UpdateSpecTable, UpdateSpecRow, Seq],
+                            success: Boolean): DBIO[Int] = {
     val query = for {
-      us <- UpdateSpecs.updateSpecs if us.requestId.in(updateRequests)
+      us <- updateSpecQuery
       ur <- UpdateRequests.all if ur.id === us.requestId
     } yield (Option.empty[Long], us.device, us.requestId, ur.packageUuid, success, Instant.now)
 

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateSpecs.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateSpecs.scala
@@ -9,12 +9,11 @@ import java.util.UUID
 import eu.timepit.refined.api.Refined
 import org.genivi.sota.core.data._
 import org.genivi.sota.core.db.UpdateRequests.UpdateRequestTable
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.genivi.sota.db.SlickExtensions
 import java.time.Instant
+import cats.syntax.show.toShowOps
 
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
-import org.genivi.sota.core.SotaCoreErrors
 import org.genivi.sota.http.Errors.MissingEntity
 import slick.driver.MySQLDriver.api._
 
@@ -128,6 +127,18 @@ object UpdateSpecs {
   }
 
   /**
+    * Look up by (UpdateRequest.UUID, Device.UUID) tuple.
+    *
+    * @param arg: Sequence of tuples (UpdateRequest.UUID, Device.UUID)
+    */
+  private def inSeq(arg: Seq[(UUID, Uuid)]): Query[UpdateSpecTable, UpdateSpecRow, Seq] = {
+    updateSpecs.filter { r =>
+      (r.requestId.mappedTo[String] ++ r.device.mappedTo[String])
+        .inSet(arg.map { case (req, device) => req.toString + device.show })
+    }
+  }
+
+  /**
     * Lookup by PK in [[UpdateSpecTable]] table.
     * Note: A tuple is returned instead of an [[UpdateSpec]] instance because
     * the later would require joining [[RequiredPackageTable]] to populate the `dependencies` of that instance.
@@ -216,16 +227,18 @@ object UpdateSpecs {
       ur <- updateRequests if ur.id === us.requestId
       pkg <- Packages.packages if pkg.uuid === ur.packageUuid &&
       pkg.namespace === namespace && pkg.name === packageId.name && pkg.version === packageId.version
-    } yield ur.id
-
-    val createHistoriesIO = InstallHistories.logAll(updateRequestIdsQuery, success = false)
+    } yield (us.requestId, us.device)
 
     // Slick does not allow us to use `in` instead of `inSet`, so we need to use DBIO instead of updateRequestIdsQuery
-    val dbIO = updateRequestIdsQuery.result.flatMap { ids =>
-      updateSpecs.filter(_.requestId.inSet(ids)).map(_.status).update(UpdateStatus.Canceled)
-    }
+    updateRequestIdsQuery.result.flatMap { ids =>
+      val updateSpecsQuery = inSeq(ids)
 
-    createHistoriesIO.andThen(dbIO).transactionally
+      val createHistoriesIO = InstallHistories.logAll(updateSpecsQuery, success = false)
+
+      val cancelIO = updateSpecsQuery.map(_.status).update(UpdateStatus.Canceled)
+
+      createHistoriesIO.andThen(cancelIO)
+    }
   }
 
 


### PR DESCRIPTION
https://advancedtelematic.atlassian.net/browse/PRO-1784

Tricky bug. cancelling packages by state would cancel update specs already finished if they belonged to the same update request with at least one Pending update spec.