### PR TITLE
[PRO-1790] Campaigns can be started with blacklisted package

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignLauncher.scala
+++ b/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignLauncher.scala
@@ -60,9 +60,10 @@ object CampaignLauncher {
     }
 
     for {
-      camp       <- db.run(Campaigns.setAsLaunch(id))
+      camp <- db.run(Campaigns.fetch(id))
       updateRefs <- camp.groups.toList.traverse(campGrp =>
         launchGroup(camp.meta.namespace, camp.packageId.get, campGrp))
+      _ <- db.run(Campaigns.setAsLaunch(id))
     } yield updateRefs
   }
 }


### PR DESCRIPTION
Fix for https://advancedtelematic.atlassian.net/browse/PRO-1790

We set the campaign as launched after we successfully created all updateRequest. It would of course be better to do it all in one big transaction but that would be a big refactoring of UpdateService, and the code wants to use either the resolver or device registry in the middle which complicates things.