### PR TITLE
Rename reserved OSTree Image field ref to imageRef

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/db/image/DataType.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/image/DataType.scala
@@ -23,7 +23,7 @@ object DataType {
   case class Image(namespace: Namespace,
                    id: ImageId,
                    commit: Commit,
-                   ref: RefName,
+                   imageRef: RefName,
                    description: String,
                    pullUri: PullUri,
                    createdAt: Instant,

--- a/core/src/main/scala/org/genivi/sota/core/db/image/ImageSchema.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/image/ImageSchema.scala
@@ -25,7 +25,7 @@ object ImageSchema {
     def namespace = column[Namespace]("namespace")
     def id = column[ImageId]("uuid")
     def commit = column[Commit]("commit")
-    def ref = column[RefName]("ref")
+    def imageRef = column[RefName]("ref")
     def description = column[String]("description")
     def pullUrl = column[PullUri]("pull_url")
     def createdAt = column[Instant]("created_at")
@@ -33,7 +33,7 @@ object ImageSchema {
 
     def pk = primaryKey("pk_image", id)
 
-    def * = (namespace, id, commit, ref, description, pullUrl, createdAt, updatedAt) <> ((Image.apply _).tupled, Image.unapply)
+    def * = (namespace, id, commit, imageRef, description, pullUrl, createdAt, updatedAt) <> ((Image.apply _).tupled, Image.unapply)
   }
 
   protected[image] val images = TableQuery[ImageTable]

--- a/core/src/main/scala/org/genivi/sota/core/db/image/Repository.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/image/Repository.scala
@@ -27,14 +27,14 @@ protected class ImageRepository()(implicit ec: ExecutionContext, db: Database) {
   import org.genivi.sota.db.SlickAnyVal._
   import org.genivi.sota.refined.SlickRefined._
 
-  def persist(ns: Namespace, commit: Commit, ref: RefName, desc: String, pullUri: PullUri): Future[Image] = {
+  def persist(ns: Namespace, commit: Commit, imageRef: RefName, desc: String, pullUri: PullUri): Future[Image] = {
     val now = Instant.now()
-    val image = Image(ns, ImageId.generate(), commit, ref, desc, pullUri, now, now)
+    val image = Image(ns, ImageId.generate(), commit, imageRef, desc, pullUri, now, now)
 
     val io = images
       .insertOrUpdateWithKey(image,
-        _.filter(_.namespace === ns).filter(_.commit === commit).filter(_.ref === ref),
-        _.copy(commit = commit, ref = ref,
+        _.filter(_.namespace === ns).filter(_.commit === commit).filter(_.imageRef === imageRef),
+        _.copy(commit = commit, imageRef = imageRef,
           description = desc, pullUri = pullUri, updatedAt = now)
       )
 

--- a/core/src/main/scala/org/genivi/sota/core/image/ImageResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/image/ImageResource.scala
@@ -16,7 +16,7 @@ import slick.driver.MySQLDriver.api._
 import scala.concurrent.ExecutionContext
 
 object ImageResource {
-  case class ImageRequest(commit: Commit, ref: RefName, description: String, pullUri: PullUri)
+  case class ImageRequest(commit: Commit, imageRef: RefName, description: String, pullUri: PullUri)
 }
 
 class ImageResource(namespace: Directive1[Namespace])(implicit db: Database, ec: ExecutionContext)
@@ -28,7 +28,7 @@ class ImageResource(namespace: Directive1[Namespace])(implicit db: Database, ec:
     path("image") {
       post {
         entity(as[ImageRequest]) { img =>
-          complete(imageRepository.persist(ns, img.commit, img.ref, img.description, img.pullUri))
+          complete(imageRepository.persist(ns, img.commit, img.imageRef, img.description, img.pullUri))
         }
       } ~
       get {

--- a/core/src/main/scala/org/genivi/sota/core/image/ImageUpdateResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/image/ImageUpdateResource.scala
@@ -23,7 +23,7 @@ object ImageUpdateResource {
   case class PendingImageUpdate(id: ImageUpdateId,
                                 imageId: ImageId,
                                 commit: Commit,
-                                ref: RefName,
+                                imageRef: RefName,
                                 description: String,
                                 pullUri: PullUri)
 
@@ -33,7 +33,7 @@ object ImageUpdateResource {
         imageUpdate.id,
         image.id,
         image.commit,
-        image.ref,
+        image.imageRef,
         image.description,
         image.pullUri
       )

--- a/core/src/test/scala/org/genivi/sota/core/image/ImageRepositorySpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/image/ImageRepositorySpec.scala
@@ -29,8 +29,8 @@ class ImageRepositorySpec extends FunSuite
     val image = imageGenerator.generate
 
     val f = for {
-      inserted <- imageRepository.persist(image.namespace, image.commit, image.ref, image.description, image.pullUri)
-      updated <- imageRepository.persist(image.namespace, image.commit, image.ref, "Other description", image.pullUri)
+      inserted <- imageRepository.persist(image.namespace, image.commit, image.imageRef, image.description, image.pullUri)
+      updated <- imageRepository.persist(image.namespace, image.commit, image.imageRef, "Other description", image.pullUri)
     } yield (inserted, updated)
 
     val (inserted, updated) = f.futureValue
@@ -43,8 +43,8 @@ class ImageRepositorySpec extends FunSuite
     val image = imageGenerator.generate
 
     val f = for {
-      _ <- imageRepository.persist(image.namespace, image.commit, image.ref, image.description, image.pullUri)
-      _ <- imageRepository.persist(image.namespace, image.commit, image.ref, "Other description", image.pullUri)
+      _ <- imageRepository.persist(image.namespace, image.commit, image.imageRef, image.description, image.pullUri)
+      _ <- imageRepository.persist(image.namespace, image.commit, image.imageRef, "Other description", image.pullUri)
       images <- imageRepository.findAll(image.namespace)
     } yield images
 
@@ -59,9 +59,9 @@ class ImageRepositorySpec extends FunSuite
     val image = imageGenerator.generate
 
     val f = for {
-      inserted <- imageRepository.persist(image.namespace, image.commit, image.ref, image.description, image.pullUri)
+      inserted <- imageRepository.persist(image.namespace, image.commit, image.imageRef, image.description, image.pullUri)
       _ <- Future.successful(Thread.sleep(2000))
-      updated <- imageRepository.persist(image.namespace, image.commit, image.ref, "Other description", image.pullUri)
+      updated <- imageRepository.persist(image.namespace, image.commit, image.imageRef, "Other description", image.pullUri)
     } yield (inserted, updated)
 
     val (inserted, updated) = f.futureValue

--- a/core/src/test/scala/org/genivi/sota/core/image/ImageResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/image/ImageResourceSpec.scala
@@ -54,7 +54,7 @@ class ImageResourceSpec extends FunSuite
   test("GET Retrieves a namespace image") {
     val imgG = imageGenerator.generate
 
-    imageRepository.persist(imgG.namespace, imgG.commit, imgG.ref, imgG.description, imgG.pullUri).futureValue
+    imageRepository.persist(imgG.namespace, imgG.commit, imgG.imageRef, imgG.description, imgG.pullUri).futureValue
 
     Get("/image") ~> route ~> check {
       status shouldBe StatusCodes.OK

--- a/core/src/test/scala/org/genivi/sota/core/image/ImageUpdateRepositorySpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/image/ImageUpdateRepositorySpec.scala
@@ -29,7 +29,7 @@ class ImageUpdateRepositorySpec extends FunSuite
     val (image, imageUpdate) = imageUpdateGenerator.generate
 
     val f = for {
-      image <- imageRepository.persist(image.namespace, image.commit, image.ref, image.description, image.pullUri)
+      image <- imageRepository.persist(image.namespace, image.commit, image.imageRef, image.description, image.pullUri)
       inserted <- imageUpdateRepository.persist(imageUpdate.namespace, image.id, imageUpdate.device)
       updated <- imageUpdateRepository.persist(imageUpdate.namespace, image.id, imageUpdate.device)
     } yield (inserted, updated)
@@ -43,7 +43,7 @@ class ImageUpdateRepositorySpec extends FunSuite
     val (image, imageUpdate) = imageUpdateGenerator.generate
 
     val f = for {
-      image <- imageRepository.persist(image.namespace, image.commit, image.ref, image.description, image.pullUri)
+      image <- imageRepository.persist(image.namespace, image.commit, image.imageRef, image.description, image.pullUri)
       inserted <- imageUpdateRepository.persist(imageUpdate.namespace, image.id, imageUpdate.device)
       updated <- imageUpdateRepository.persist(imageUpdate.namespace, image.id, imageUpdate.device)
     } yield (inserted, updated)

--- a/core/src/test/scala/org/genivi/sota/core/image/ImageUpdateResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/image/ImageUpdateResourceSpec.scala
@@ -95,7 +95,7 @@ class ImageUpdateResourceSpec extends FunSuite
 
       queue.map(_.imageId) should contain(img.id)
       queue.map(_.commit) should contain(commit)
-      queue.map(_.ref) should contain(refName)
+      queue.map(_.imageRef) should contain(refName)
     }
   }
 }


### PR DESCRIPTION
As part of [PRO-1722](https://advancedtelematic.atlassian.net/browse/PRO-1722), this renames the newly created `ref` field to `imageRef` (except in the database) as this simplifies the implementation on the client side by not using a reserved word.