### PR TITLE
[PRO-1930] add coverage-checking

### DIFF
--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -6,6 +6,7 @@ import sbt._
 import sbt.Keys._
 import sbtbuildinfo._
 import sbtbuildinfo.BuildInfoKeys._
+import scoverage.ScoverageKeys._
 import com.typesafe.sbt.packager.docker.DockerPlugin
 import DockerPlugin.autoImport.Docker
 import com.typesafe.sbt.packager.Keys._
@@ -25,6 +26,7 @@ object SotaBuild extends Build {
     organization := "org.genivi",
     scalaVersion := "2.11.8",
     publishArtifact in Test := false,
+    coverageOutputTeamCity := true,
     resolvers += Resolver.sonatypeRepo("snapshots"),
     resolvers += "Sonatype Nexus Repository Manager" at "http://nexus.advancedtelematic.com:8081/content/repositories/releases",
     resolvers += "version99 Empty loggers" at "http://version99.qos.ch",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.4.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 


### PR DESCRIPTION
We need ```coverageOutputTeamCity``` to be ```true``` in order to create ```coverage.zip``` which is what teamcity uses to display the coverage (I think).