### PR TITLE
[PRO-1935] Add linting to core

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/BlacklistResource.scala
@@ -10,16 +10,15 @@ import org.genivi.sota.http.ErrorHandler._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Directive1, Route}
-import org.genivi.sota.core.db.{BlacklistedPackageRequest, BlacklistedPackages, InstallHistories, UpdateSpecs}
+import org.genivi.sota.core.db.{BlacklistedPackageRequest, BlacklistedPackages, UpdateSpecs}
 import org.genivi.sota.data.{Namespace, PackageId}
 import slick.driver.MySQLDriver.api._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
-import org.genivi.sota.marshalling.RefinedMarshallingSupport._
 import io.circe.generic.auto._
 import org.genivi.sota.messaging.MessageBusPublisher
 import org.genivi.sota.messaging.Messages.PackageBlacklisted
 import org.genivi.sota.messaging.Messages._
-import org.genivi.sota.core.data.{InstallHistory, UpdateStatus}
+import org.genivi.sota.core.data.UpdateStatus
 import org.genivi.sota.core.transfer.DeviceUpdates
 import org.genivi.sota.rest.ToResponse
 

--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -20,7 +20,6 @@ import org.genivi.sota.core.resolver._
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.core.storage.S3PackageStore
 import org.genivi.sota.core.transfer._
-import org.genivi.sota.data.Namespace
 import org.genivi.sota.db.BootMigrations
 import org.genivi.sota.http._
 import org.genivi.sota.http.LogDirectives._

--- a/core/src/main/scala/org/genivi/sota/core/DeviceUpdatesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DeviceUpdatesResource.scala
@@ -24,17 +24,13 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 
 import org.genivi.sota.core.transfer.DeviceUpdates
-import org.genivi.sota.core.data.{UpdateRequest, UpdateSpec}
-import org.genivi.sota.core.data.client.PendingUpdateRequest
-import org.genivi.sota.core.data.UpdateStatus
+import org.genivi.sota.core.data.UpdateSpec
 import org.genivi.sota.core.transfer.{DefaultUpdateNotifier, PackageDownloadProcess}
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 
-import scala.language.implicitConversions
 import slick.driver.MySQLDriver.api.Database
 import cats.syntax.show.toShowOps
 import org.genivi.sota.http.AuthedNamespaceScope
-import org.genivi.sota.http.NamespaceDirectives
 import org.genivi.sota.messaging.MessageBusPublisher
 import org.genivi.sota.core.data.client.PendingUpdateRequest._
 import UpdateSpec._
@@ -50,11 +46,9 @@ class DeviceUpdatesResource(db: Database,
                            (implicit system: ActorSystem, mat: ActorMaterializer,
                             connectivity: Connectivity = DefaultConnectivity) {
 
-  import shapeless._
   import Directives._
   import org.genivi.sota.http.UuidDirectives._
   import org.genivi.sota.marshalling.CirceMarshallingSupport._
-  import Device._
   import org.genivi.sota.http.ErrorHandler._
 
   implicit val ec = system.dispatcher

--- a/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DevicesResource.scala
@@ -26,8 +26,6 @@ import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.genivi.sota.marshalling.RefinedMarshallingSupport._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.languageFeature.implicitConversions
-import scala.languageFeature.postfixOps
 import scala.util.{Failure, Success}
 import slick.driver.MySQLDriver.api.Database
 import Device._

--- a/core/src/main/scala/org/genivi/sota/core/DigestCalculator.scala
+++ b/core/src/main/scala/org/genivi/sota/core/DigestCalculator.scala
@@ -7,11 +7,8 @@ package org.genivi.sota.core
 import java.security.MessageDigest
 
 import akka.stream.scaladsl.Sink
-import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
-import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.util.ByteString
 import org.apache.commons.codec.binary.Hex
-import org.genivi.sota.core.DigestCalculator.DigestResult
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/core/src/main/scala/org/genivi/sota/core/HistoryResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/HistoryResource.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.server.{Directive1, Directives, Route}
 import eu.timepit.refined.api.Refined
 import io.circe.generic.auto._
-import org.genivi.sota.core.data.InstallHistory
 import org.genivi.sota.core.db.InstallHistories
 import org.genivi.sota.data.{Namespace, Uuid}
 import org.genivi.sota.http.AuthedNamespaceScope

--- a/core/src/main/scala/org/genivi/sota/core/ImpactResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/ImpactResource.scala
@@ -8,7 +8,6 @@ import org.genivi.sota.core.db.BlacklistedPackages
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.{Directive1, Directives, Route}
 import org.genivi.sota.data.Namespace
-import io.circe.generic.auto._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import slick.driver.MySQLDriver.api._
 import Directives._

--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -31,10 +31,7 @@ import org.genivi.sota.rest.Validation._
 import slick.driver.MySQLDriver.api.Database
 import org.genivi.sota.rest.ResponseConversions._
 import org.genivi.sota.core.data.PackageResponse._
-import cats.std.future._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
-import akka.http.scaladsl.marshalling._
-import akka.http.scaladsl.unmarshalling._
 import io.circe.generic.auto._
 import org.genivi.sota.core.SotaCoreErrors.SotaCoreErrorCodes
 import org.genivi.sota.http.AuthedNamespaceScope

--- a/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/UpdateService.scala
@@ -8,14 +8,13 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.util.FastFuture
 import cats.Show
-import eu.timepit.refined._
 import eu.timepit.refined.string._
 import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.core.data._
 import org.genivi.sota.core.db._
 import org.genivi.sota.core.resolver.Connectivity
 import org.genivi.sota.core.transfer.UpdateNotifier
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import java.time.Instant
 import java.util.UUID
 
@@ -26,7 +25,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
 import slick.dbio.DBIO
 import slick.driver.MySQLDriver.api._
-import org.genivi.sota.db.Operators._
 
 case class PackagesNotFound(packageIds: (PackageId)*)
                            (implicit show: Show[PackageId])

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -11,7 +11,6 @@ import akka.stream.ActorMaterializer
 import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.core.resolver.{Connectivity, ExternalResolverClient}
 import org.genivi.sota.core.transfer.UpdateNotifier
-import org.genivi.sota.data.Namespace
 import org.genivi.sota.http.AuthedNamespaceScope
 
 import scala.concurrent.ExecutionContext

--- a/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignStats.scala
+++ b/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignStats.scala
@@ -4,7 +4,6 @@
   */
 package org.genivi.sota.core.campaigns
 
-import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.core.UpdateService
 import org.genivi.sota.core.data.Campaign.CampaignGroup
 import org.genivi.sota.core.data.{Campaign, CampaignStatistics, UpdateStatus}

--- a/core/src/main/scala/org/genivi/sota/core/data/BlockedInstall.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/BlockedInstall.scala
@@ -6,8 +6,7 @@ package org.genivi.sota.core.data
 
 import java.time.Instant
 
-import org.genivi.sota.data.{Device, Uuid}
-import eu.timepit.refined.api.Refined
+import org.genivi.sota.data.Uuid
 
 case class BlockedInstall(id: Uuid, blockedAt: Instant)
 

--- a/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/Campaign.scala
@@ -6,10 +6,8 @@ package org.genivi.sota.core.data
 
 import cats.Show
 import cats.data.Xor
-import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
 import io.circe._
-import io.circe.generic.auto._
 import java.time.Instant
 import java.util.UUID
 import org.genivi.sota.core.SotaCoreErrors

--- a/core/src/main/scala/org/genivi/sota/core/data/DeviceSearch.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/DeviceSearch.scala
@@ -9,7 +9,6 @@ import org.genivi.sota.core.data.DeviceStatus.DeviceStatus
 import org.genivi.sota.core.data.UpdateStatus.UpdateStatus
 import org.genivi.sota.core.db.UpdateSpecs
 import org.genivi.sota.data.{CirceEnum, Device, Uuid}
-import org.genivi.sota.data.Namespace._
 import org.genivi.sota.refined.SlickRefined._
 import org.slf4j.LoggerFactory
 

--- a/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/InstallHistory.scala
@@ -4,10 +4,9 @@
  */
 package org.genivi.sota.core.data
 
-import org.genivi.sota.data.Namespace
 import java.time.Instant
-import org.genivi.sota.data.{Device, PackageId, Uuid}
 import java.util.UUID
+import org.genivi.sota.data.{PackageId, Uuid}
 
 import org.genivi.sota.rest.GenericResponseEncoder
 

--- a/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/UpdateRequest.scala
@@ -9,8 +9,7 @@ import java.util.UUID
 import org.genivi.sota.data.Interval
 import java.time.Instant
 import java.time.Duration
-import org.genivi.sota.data.{PackageId, Device, Namespace, Uuid}
-import org.genivi.sota.core.db.InstallHistories.InstallHistoryTable
+import org.genivi.sota.data.{Namespace, Uuid}
 
 /**
  * Domain object for an update request.
@@ -44,8 +43,6 @@ case class UpdateRequest(
   installPos: Int = 0)
 
 object UpdateRequest {
-
-  import eu.timepit.refined.auto._
 
   def default(namespace: Namespace, packageUuid: UUID): UpdateRequest = {
     val updateRequestId = UUID.randomUUID()

--- a/core/src/main/scala/org/genivi/sota/core/data/client/PendingUpdateRequest.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/client/PendingUpdateRequest.scala
@@ -13,10 +13,8 @@ import java.time.Instant
 
 import org.genivi.sota.core.data.UpdateStatus.UpdateStatus
 
-import scala.language.implicitConversions
 import org.genivi.sota.data.Interval
 import org.genivi.sota.rest.{GenericArgsDecoder, GenericResponseEncoder}
-import shapeless.{::, HNil}
 
 case class PendingUpdateRequest(requestId: UUID,
                                 packageId: PackageId,

--- a/core/src/main/scala/org/genivi/sota/core/db/BlacklistedPackages.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/BlacklistedPackages.scala
@@ -4,12 +4,12 @@ import java.time.Instant
 import java.util.UUID
 
 import org.genivi.sota.core.SotaCoreErrors
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import slick.driver.MySQLDriver.api._
 
 import scala.concurrent.{ExecutionContext, Future}
 import org.genivi.sota.core.data.Package
-import org.genivi.sota.core.db.Packages.{LiftedPackageId, PackageTable}
+import org.genivi.sota.core.db.Packages.LiftedPackageId
 import org.genivi.sota.http.Errors
 import org.genivi.sota.http.Errors.MissingEntity
 import org.genivi.sota.rest.GenericResponseEncoder

--- a/core/src/main/scala/org/genivi/sota/core/db/BlockedInstalls.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/BlockedInstalls.scala
@@ -4,8 +4,7 @@
   */
 package org.genivi.sota.core.db
 
-import org.genivi.sota.data.{Device, Uuid}
-import org.genivi.sota.data.Namespace._
+import org.genivi.sota.data.Uuid
 import org.genivi.sota.core.data.BlockedInstall
 import org.genivi.sota.refined.SlickRefined._
 import java.time.Instant
@@ -17,7 +16,6 @@ import slick.driver.MySQLDriver.api._
 object BlockedInstalls {
 
   import org.genivi.sota.db.SlickExtensions._
-  import Device._
 
   // scalastyle:off
   class BlockedInstallTable(tag: Tag) extends Table[BlockedInstall](tag, "BlockedInstall") {

--- a/core/src/main/scala/org/genivi/sota/core/db/Campaigns.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Campaigns.scala
@@ -5,12 +5,10 @@
 package org.genivi.sota.core.db
 
 import cats.data.Xor
-import eu.timepit.refined.refineV
 import java.util.UUID
 import org.genivi.sota.core.data.Campaign
 import org.genivi.sota.core.SotaCoreErrors
 import org.genivi.sota.data.{Namespace, PackageId, Uuid}
-import org.genivi.sota.db.Operators._
 import org.genivi.sota.refined.SlickRefined._
 import scala.concurrent.ExecutionContext
 import slick.driver.MySQLDriver.api._
@@ -35,7 +33,7 @@ object Campaigns {
       ,(x: CampaignMeta) => Some((x.id, x.namespace, x.name, x.launched, x.packageUuid.map(_.toJava))))
 
     def uniqueName = index("Campaign_unique_name", (namespace, name), unique = true)
-    def fkPkg = foreignKey("Campaign_pkg_fk", packageUuid, Packages.packages)(_.uuid)
+    def fkPkg = foreignKey("Campaign_pkg_fk", packageUuid, Packages.packages)(_.uuid.?)
   }
   // scalastyle:on
 

--- a/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/InstallHistories.scala
@@ -4,7 +4,7 @@
  */
 package org.genivi.sota.core.db
 
-import org.genivi.sota.core.data.{InstallHistory, UpdateRequest, UpdateSpec, UpdateStatus}
+import org.genivi.sota.core.data.{InstallHistory, UpdateSpec, UpdateStatus}
 import java.time.Instant
 import java.util.UUID
 
@@ -15,7 +15,7 @@ import org.genivi.sota.http.Errors
 import shapeless._
 import slick.driver.MySQLDriver.api._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 
 /**
@@ -28,8 +28,6 @@ object InstallHistories {
 
   import org.genivi.sota.db.SlickExtensions._
   import org.genivi.sota.refined.SlickRefined._
-  import UpdateStatus._
-  import org.genivi.sota.db.Operators._
   import UpdateSpecs.UpdateStatusColumn
 
   /**

--- a/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/OperationResults.scala
@@ -8,8 +8,7 @@ import eu.timepit.refined.api.Refined
 import java.util.UUID
 
 import org.genivi.sota.core.data.OperationResult
-import org.genivi.sota.core.data.UpdateRequest
-import org.genivi.sota.data.{Device, Namespace, Uuid}
+import org.genivi.sota.data.{Namespace, Uuid}
 
 import scala.concurrent.ExecutionContext
 import slick.driver.MySQLDriver.api._
@@ -38,8 +37,6 @@ object OperationResults {
     def device      = column[Uuid]("device_uuid")
     def namespace   = column[Namespace]("namespace")
     def receivedAt  = column[Instant]("received_at")
-
-    import shapeless._
 
     def pk = primaryKey("pk_OperationResultTable", id)
 

--- a/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/Packages.scala
@@ -11,10 +11,9 @@ import org.genivi.sota.core.SotaCoreErrors
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.data.Namespace
 import org.genivi.sota.data.PackageId
-import org.genivi.sota.db.SlickExtensions._
 import slick.driver.MySQLDriver.api._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 /**
  * Database mapping definition for the Package SQL table. This defines all the

--- a/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/UpdateRequests.scala
@@ -28,7 +28,6 @@ object UpdateRequests {
   import org.genivi.sota.db._
   import SlickExtensions._
   import org.genivi.sota.refined.SlickRefined._
-  import Operators._
 
   // scalastyle:off
   /**

--- a/core/src/main/scala/org/genivi/sota/core/jsonrpc/JsonRpcDirectives.scala
+++ b/core/src/main/scala/org/genivi/sota/core/jsonrpc/JsonRpcDirectives.scala
@@ -4,14 +4,11 @@
  */
 package org.genivi.sota.core.jsonrpc
 
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
-import cats.data.Xor
 import io.circe.DecodingFailure
 import io.circe._
 import org.genivi.sota.marshalling.CirceMarshallingSupport
 import scala.concurrent.ExecutionContext
-import shapeless.HList
 
 import scala.concurrent.Future
 
@@ -62,9 +59,6 @@ trait JsonRpcDirectives {
   implicit def lift[In, Out](fn: In => Future[Out])
                    (implicit inDecoder: Decoder[In], outEncoder: Encoder[Out], ec: ExecutionContext)
       : MethodFn = request => {
-    import shapeless._
-    import record._
-    import syntax.singleton._
 
     inDecoder.decodeJson( request.params ).map( fn ).fold[StandardRoute](
       err =>

--- a/core/src/main/scala/org/genivi/sota/core/jsonrpc/client.scala
+++ b/core/src/main/scala/org/genivi/sota/core/jsonrpc/client.scala
@@ -80,7 +80,6 @@ object client extends Dynamic {
   final case class Request(method: String, params: Json, id: Int) {
 
     import shapeless._
-    import record._
     import syntax.singleton._
     import io.circe.generic.auto._
 

--- a/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
+++ b/core/src/main/scala/org/genivi/sota/core/resolver/ExternalResolverClient.scala
@@ -14,8 +14,7 @@ import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
-import Device._
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import akka.http.scaladsl.marshalling.Marshal
 import cats.syntax.show._
 import org.genivi.sota.http.NamespaceDirectives.nsHeader
@@ -115,7 +114,6 @@ class DefaultExternalResolverClient(baseUri : Uri, resolveUri: Uri, packagesUri:
     extends ExternalResolverClient {
 
   import CirceMarshallingSupport._
-  import io.circe._
   import system.dispatcher
   import io.circe.generic.auto._
   import akka.http.scaladsl.model.headers._

--- a/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/RviUpdateNotifier.scala
@@ -4,12 +4,11 @@
  */
 package org.genivi.sota.core.rvi
 
-import akka.event.LoggingAdapter
 import org.genivi.sota.core.data.UpdateSpec
 import org.genivi.sota.core.resolver.Connectivity
 import org.genivi.sota.core.transfer._
 import java.time.Instant
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -18,8 +17,6 @@ import scala.concurrent.{ExecutionContext, Future}
  * can/should be updated.
  */
 class RviUpdateNotifier(services: ServerServices) extends UpdateNotifier {
-
-  import io.circe.generic.auto._
 
   override def notifyDevice(device: Uuid, update: UpdateSpec)
                             (implicit connectivity: Connectivity, ec: ExecutionContext): Future[Int] = {

--- a/core/src/main/scala/org/genivi/sota/core/rvi/SotaServices.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/SotaServices.scala
@@ -10,14 +10,12 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Directives
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import eu.timepit.refined.api.Refined
 import io.circe.Json
 import java.util.UUID
 
 import org.genivi.sota.common.DeviceRegistry
 import org.genivi.sota.core.resolver.{Connectivity, ExternalResolverClient}
-import org.genivi.sota.core.data.UpdateRequest
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -112,7 +110,6 @@ class SotaServices(updateController: ActorRef, resolverClient: ExternalResolverC
 }
 
 object SotaServices {
-  import io.circe._
   import org.genivi.sota.core.jsonrpc.client
 
   private[this] def registerService(name: String, uri: Uri)

--- a/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
+++ b/core/src/main/scala/org/genivi/sota/core/rvi/TransferController.scala
@@ -16,7 +16,7 @@ import java.nio.file.{Paths, StandardOpenOption}
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-import org.genivi.sota.core.data.{Package, UpdateRequest, UpdateSpec, UpdateStatus}
+import org.genivi.sota.core.data.{Package, UpdateStatus}
 import akka.actor._
 import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
@@ -29,7 +29,7 @@ import java.time.Instant
 import java.time.Duration
 
 import org.genivi.sota.core.transfer.DeviceUpdates
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import org.genivi.sota.messaging.MessageBusPublisher
 
 import scala.collection.immutable.Queue
@@ -37,7 +37,6 @@ import scala.concurrent.duration.FiniteDuration
 import scala.math.BigDecimal.RoundingMode
 import slick.driver.MySQLDriver.api.Database
 
-import scala.collection.LinearSeq
 import scala.util.Try
 
 
@@ -135,8 +134,6 @@ class TransferProtocolActor(db: Database,
                             transferActorProps: (UUID, String, Package, ClientServices) => Props,
                             messageBus: MessageBusPublisher)
     extends Actor with ActorLogging {
-  import cats.syntax.eq._
-  import cats.syntax.show._
   import context.dispatcher
 
   val installTimeout : FiniteDuration = FiniteDuration(
@@ -421,7 +418,7 @@ class PackageTransferActor(updateId: UUID,
         case first :: second :: Nil => second - first > 1
         case first :: Nil => true
         case _ => false
-      }.map {
+      }.collect {
         case first :: _ :: Nil => first + 1
         case 1 :: Nil => 2
         case Nil => 1

--- a/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/LocalPackageStore.scala
@@ -10,7 +10,6 @@ import java.nio.file.Paths
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.http.scaladsl.common.StrictForm
 import akka.http.scaladsl.model._
 import akka.stream._
 import akka.stream.scaladsl.{FileIO, Sink, Source}

--- a/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/PackageStorage.scala
@@ -7,10 +7,8 @@ package org.genivi.sota.core.storage
 import java.nio.ByteBuffer
 import java.security.MessageDigest
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
-import akka.http.scaladsl.common.StrictForm
 import akka.stream._
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString

--- a/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/S3PackageStore.scala
@@ -4,26 +4,22 @@
  */
 package org.genivi.sota.core.storage
 
-import java.io.{File, FileInputStream, InputStream}
+import java.io.File
 
 import akka.actor.ActorSystem
-import akka.event.Logging
-import akka.http.scaladsl.common.StrictForm.FileData
 import akka.http.scaladsl.model._
 import akka.stream._
-import akka.stream.scaladsl.{FileIO, Sink, Source, StreamConverters}
+import akka.stream.scaladsl.{FileIO, Source}
 import com.amazonaws.auth.AWSCredentials
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model._
 import com.typesafe.config.Config
 import org.genivi.sota.core.DigestCalculator.DigestResult
-import org.genivi.sota.core.data.Package
 import org.genivi.sota.data.PackageId
 import java.time.{Duration, Instant}
 
 import akka.util.ByteString
-import com.amazonaws.services.s3.transfer.TransferManager
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future

--- a/core/src/main/scala/org/genivi/sota/core/transfer/DeviceUpdates.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/DeviceUpdates.scala
@@ -11,33 +11,27 @@ import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import cats.Show
 import io.circe.Json
 import io.circe.syntax._
-import org.genivi.sota.core.SotaCoreErrors
 import org.genivi.sota.core.data.UpdateStatus.UpdateStatus
 import org.genivi.sota.core.data._
 import org.genivi.sota.core.db.UpdateSpecs._
 import org.genivi.sota.core.db._
 import org.genivi.sota.core.resolver.ExternalResolverClient
 import org.genivi.sota.core.rvi.UpdateReport
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
-import org.genivi.sota.db.Operators._
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.genivi.sota.db.SlickExtensions
-import org.genivi.sota.http.Errors
 import org.genivi.sota.http.Errors.MissingEntity
 import org.genivi.sota.messaging.{MessageBusPublisher, Messages}
 import slick.dbio.DBIO
 import slick.driver.MySQLDriver.api._
 import Packages.{LiftedPackageId, LiftedPackageShape}
-import org.genivi.sota.core.db.UpdateRequests.UpdateRequestTable
-import shapeless.{HList, ::, HNil}
+import shapeless.{::, HNil}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
 import scala.util.control.NoStackTrace
 
 object DeviceUpdates {
   import SlickExtensions._
   import org.genivi.sota.marshalling.CirceInstances._
-  import org.genivi.sota.db.Operators._
   import org.genivi.sota.refined.SlickRefined._
 
   case class SetOrderFailed(msg: String) extends Exception(msg) with NoStackTrace

--- a/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/PackageDownloadProcess.scala
@@ -11,26 +11,22 @@ import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import eu.timepit.refined.api.Refined
 import org.genivi.sota.core.SotaCoreErrors
-import org.genivi.sota.core.data.{Package, UpdateSpec, UpdateStatus}
+import org.genivi.sota.core.data.{Package, UpdateStatus}
 import org.genivi.sota.core.db.{BlacklistedPackages, Packages, UpdateSpecs}
 import org.genivi.sota.core.db.UpdateSpecs._
 import org.genivi.sota.core.storage.PackageStorage.PackageRetrievalOp
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import org.genivi.sota.db.SlickExtensions
 import org.genivi.sota.refined.SlickRefined._
 import slick.driver.MySQLDriver.api._
-import org.genivi.sota.db.Operators._
 
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.implicitConversions
 
 
 class PackageDownloadProcess(db: Database, packageRetrieval: PackageRetrievalOp)
                             (implicit val system: ActorSystem, mat: ActorMaterializer) {
   import SlickExtensions._
-  import org.genivi.sota.core.storage.PackageStorage
-  import org.genivi.sota.core.data.UpdateRequest
 
   /**
     * <ul>

--- a/core/src/main/scala/org/genivi/sota/core/transfer/UpdateNotifier.scala
+++ b/core/src/main/scala/org/genivi/sota/core/transfer/UpdateNotifier.scala
@@ -7,10 +7,10 @@ package org.genivi.sota.core.transfer
 import akka.event.LoggingAdapter
 import java.util.UUID
 
-import org.genivi.sota.core.data.{Package, UpdateSpec}
+import org.genivi.sota.core.data.UpdateSpec
 import org.genivi.sota.core.resolver.Connectivity
 import org.genivi.sota.core.rvi.ServerServices
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import scala.concurrent.{ExecutionContext, Future}
 
 

--- a/core/src/test/scala/org/genivi/sota/core/CampaignResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/CampaignResourceSpec.scala
@@ -11,17 +11,16 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.implicits._
 import io.circe.generic.auto._
 import java.util.UUID
-import org.genivi.sota.core.data.{Campaign, UpdateRequest, UpdateStatus}
+import org.genivi.sota.core.data.{Campaign, UpdateStatus}
 import org.genivi.sota.core.db.{BlacklistedPackages, Packages, UpdateRequests}
 import org.genivi.sota.core.resolver.DefaultConnectivity
 import org.genivi.sota.core.transfer.DefaultUpdateNotifier
-import org.genivi.sota.data.{Interval, Namespaces, PackageId, Uuid, UuidGenerator}
+import org.genivi.sota.data.{Namespaces, PackageId, Uuid}
 import org.genivi.sota.http.NamespaceDirectives.defaultNamespaceExtractor
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, ShouldMatchers}
-import scala.concurrent.Future
 
 class CampaignResourceSpec extends FunSuite
     with ScalatestRouteTest

--- a/core/src/test/scala/org/genivi/sota/core/DeviceResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DeviceResourceSpec.scala
@@ -5,7 +5,6 @@
 package org.genivi.sota.core
 
 import java.time.Instant
-import java.time.chrono.Chronology
 import java.time.temporal.ChronoUnit
 
 import akka.http.scaladsl.model.{StatusCodes, Uri}
@@ -14,7 +13,7 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.http.scaladsl.unmarshalling.Unmarshaller._
 import io.circe.generic.auto._
-import org.genivi.sota.core.data.{DeviceStatus, DeviceUpdateStatus}
+import org.genivi.sota.core.data.DeviceStatus
 import org.genivi.sota.core.jsonrpc.HttpTransport
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.data._
@@ -40,8 +39,6 @@ class DeviceResourceSpec extends FunSuite
   with Namespaces {
 
   import CirceMarshallingSupport._
-  import Generators._
-  import PackageIdGenerators._
   import DeviceGenerators._
   import NamespaceDirectives._
 

--- a/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DeviceUpdatesResourceSpec.scala
@@ -44,7 +44,6 @@ class DeviceUpdatesResourceSpec extends FunSuite
 
   import Arbitrary._
   import NamespaceDirectives._
-  import Device._
   import DeviceGenerators._
   import PackageIdGenerators._
   import UpdateSpec._

--- a/core/src/test/scala/org/genivi/sota/core/DigestCalculatorSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/DigestCalculatorSpec.scala
@@ -6,17 +6,13 @@ package org.genivi.sota.core
 
 import java.io.File
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{FileIO, Keep, Sink, Source}
-import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.scaladsl.{FileIO, Source}
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuiteLike, ShouldMatchers}
-
-import scala.concurrent.Future
 
 class DigestCalculatorSpec extends TestKit(ActorSystem("DigestCalculatorTest"))
   with FunSuiteLike

--- a/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
+++ b/core/src/test/scala/org/genivi/sota/core/FakeExternalResolver.scala
@@ -2,11 +2,10 @@ package org.genivi.sota.core
 
 import akka.actor.ActorSystem
 import akka.event.Logging
-import akka.http.scaladsl.model.{HttpResponse, Uri}
 import akka.stream.ActorMaterializer
 import io.circe.Json
-import org.genivi.sota.core.resolver.{DefaultExternalResolverClient, ExternalResolverClient}
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.core.resolver.ExternalResolverClient
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 
 import scala.concurrent.Future
 

--- a/core/src/test/scala/org/genivi/sota/core/Generators.scala
+++ b/core/src/test/scala/org/genivi/sota/core/Generators.scala
@@ -26,7 +26,6 @@ trait Generators {
 
   import Arbitrary._
   import Campaign._
-  import DeviceGenerators._
   import Namespaces._
   import UuidGenerator._
 

--- a/core/src/test/scala/org/genivi/sota/core/ImpactResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/ImpactResourceSpec.scala
@@ -8,13 +8,11 @@ package org.genivi.sota.core
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.genivi.sota.core.db.BlacklistedPackages
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, ShouldMatchers}
 import org.genivi.sota.http.NamespaceDirectives._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
-import org.genivi.sota.marshalling.RefinedMarshallingSupport._
-import io.circe.generic.auto._
 
 import scala.concurrent.Future
 

--- a/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageResourceWordSpec.scala
@@ -20,7 +20,6 @@ import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.Await
 import slick.driver.MySQLDriver.api._
-import DataPackage._
 import org.genivi.sota.data.PackageId
 import org.genivi.sota.http.NamespaceDirectives
 

--- a/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackageUploadSpec.scala
@@ -3,20 +3,17 @@ package org.genivi.sota.core
 import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 import akka.http.scaladsl.model.Uri.Path
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.PathMatchers
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.http.scaladsl.unmarshalling._
 import io.circe.generic.auto._
 import java.io.File
 
 import org.genivi.sota.core.SotaCoreErrors.SotaCoreErrorCodes
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.resolver.{ExternalResolverClient, ExternalResolverRequestFailed}
-import org.genivi.sota.data.{Device, Namespace, PackageId, Uuid}
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
 import org.genivi.sota.http.NamespaceDirectives
 import org.genivi.sota.marshalling.CirceMarshallingSupport
-import org.genivi.sota.messaging.Messages.PackageCreated
 import org.genivi.sota.messaging.MessageBusPublisher
 import org.genivi.sota.rest.ErrorRepresentation
 import org.scalatest.concurrent.ScalaFutures
@@ -26,7 +23,6 @@ import org.scalatest.{Matchers, PropSpec}
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import slick.jdbc.JdbcBackend.Database
 
 
 /**

--- a/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/PackagesResourceSpec.scala
@@ -8,7 +8,6 @@ package org.genivi.sota.core
 import java.io.File
 import java.net.URI
 
-import cats.syntax.show._
 import org.genivi.sota.data.PackageId._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import io.circe.generic.auto._

--- a/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/TestDatabase.scala
@@ -4,10 +4,8 @@
   */
 package org.genivi.sota.core
 
-import akka.http.scaladsl.util.FastFuture
-import com.typesafe.config.{Config, ConfigFactory}
-import org.genivi.sota.common.DeviceRegistry
-import org.genivi.sota.core.data.{Package, UpdateRequest, UpdateSpec}
+import com.typesafe.config.ConfigFactory
+import org.genivi.sota.core.data.{Package, UpdateSpec}
 import org.genivi.sota.core.db.{Packages, UpdateRequests, UpdateSpecs}
 import org.genivi.sota.data._
 import org.genivi.sota.http.NamespaceDirectives
@@ -18,7 +16,6 @@ import slick.driver.MySQLDriver.api._
 
 object NamespaceSpec {
   import eu.timepit.refined.auto._
-  import eu.timepit.refined.string._
 
   lazy val defaultNamespace: Namespace = {
     val config = ConfigFactory.load()

--- a/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/UpdateRequestResourceSpec.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.testkit.ScalatestRouteTest
 import io.circe.Encoder
 import io.circe.generic.auto._
 import org.genivi.sota.core.resolver.{ConnectivityClient, DefaultConnectivity}
-import org.genivi.sota.core.data.UpdateSpec
 import org.genivi.sota.core.data.client.ClientUpdateRequest
 import org.genivi.sota.core.transfer.DefaultUpdateNotifier
 import org.genivi.sota.marshalling.CirceMarshallingSupport
@@ -18,7 +17,6 @@ import java.time.temporal.ChronoUnit
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSuite, ShouldMatchers}
-import akka.http.scaladsl.unmarshalling._
 import org.genivi.sota.data.{Interval, Namespaces}
 import org.genivi.sota.http.NamespaceDirectives
 
@@ -34,7 +32,6 @@ class UpdateRequestResourceSpec extends FunSuite
   with LongRequestTimeout {
 
   import CirceMarshallingSupport._
-  import UpdateSpec._
   import NamespaceDirectives._
 
   implicit val log = Logging(system, "UpdateRequestResourceSpec")

--- a/core/src/test/scala/org/genivi/sota/core/jsonrpc/HttpTransportSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/jsonrpc/HttpTransportSpec.scala
@@ -8,10 +8,9 @@ import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.Uri
 import io.circe._
-import org.genivi.sota.marshalling.{DeserializationException, CirceMarshallingSupport}
+import org.genivi.sota.marshalling.CirceMarshallingSupport
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
-import org.scalatest.{PropSpec, Matchers}
 import CirceMarshallingSupport._
 import org.scalatest.concurrent.ScalaFutures._
 

--- a/core/src/test/scala/org/genivi/sota/core/jsonrpc/JsonRpcSpecBase.scala
+++ b/core/src/test/scala/org/genivi/sota/core/jsonrpc/JsonRpcSpecBase.scala
@@ -6,7 +6,6 @@ import io.circe._
 import io.circe.syntax._
 import org.scalatest.{PropSpec, Matchers, BeforeAndAfterAll}
 import org.scalatest.prop.PropertyChecks
-import scala.concurrent.Future
 
 /**
  * Base class for JSON-RPC property-based specs

--- a/core/src/test/scala/org/genivi/sota/core/resolver/ExternalResolverClientSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/resolver/ExternalResolverClientSpec.scala
@@ -10,9 +10,7 @@ import akka.stream.ActorMaterializer
 import cats.data.Xor
 import eu.timepit.refined.api.Refined
 import io.circe.jawn._
-import org.genivi.sota.data.{Device, PackageId, Uuid}
-import io.circe.generic.auto._
-import Device._
+import org.genivi.sota.data.{PackageId, Uuid}
 import cats.syntax.show._
 import org.genivi.sota.marshalling.CirceMarshallingSupport._
 import org.scalatest.concurrent.ScalaFutures

--- a/core/src/test/scala/org/genivi/sota/core/rvi/PackageTransferSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/rvi/PackageTransferSpec.scala
@@ -5,24 +5,17 @@ import akka.actor.ActorLogging
 import akka.actor.ActorRef
 import akka.actor.Props
 import akka.actor.Stash
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
-import akka.parboiled2.util.Base64
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import io.circe.Encoder
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption
-import java.util.UUID
 import java.security.MessageDigest
 
 import org.apache.commons.codec.binary.Hex
 import org.genivi.sota.core.Generators
-import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.resolver.ConnectivityClient
 import java.time.Instant
-import org.genivi.sota.data.{Device, Uuid}
+import org.genivi.sota.data.Uuid
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}

--- a/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/LocalPackageStoreSpec.scala
@@ -6,14 +6,13 @@ package org.genivi.sota.core.storage
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.common.StrictForm
-import akka.http.scaladsl.model.{HttpEntity, Uri}
+import akka.http.scaladsl.model.HttpEntity
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.ByteString
 import org.genivi.sota.core.DefaultPatience
 import org.genivi.sota.data.PackageIdGenerators
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSuiteLike, ShouldMatchers}
 
 class LocalPackageStoreSpec extends TestKit(ActorSystem("LocalPackageStoreSpec"))

--- a/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/storage/S3PackageStoreSpec.scala
@@ -12,7 +12,6 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.FileIO
 import akka.testkit.TestKit
 import akka.util.ByteString
-import com.typesafe.config.ConfigFactory
 import org.genivi.sota.core.IntegrationTest
 import org.genivi.sota.data.PackageIdGenerators
 import org.scalatest.concurrent.ScalaFutures

--- a/core/src/test/scala/org/genivi/sota/core/transfer/DeviceUpdatesSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/DeviceUpdatesSpec.scala
@@ -10,15 +10,11 @@ import org.genivi.sota.core.data.{UpdateSpec, UpdateStatus}
 import org.genivi.sota.core.db._
 import org.genivi.sota.core.rvi.OperationResult
 import org.genivi.sota.core.rvi.UpdateReport
-import org.genivi.sota.data.{Device, DeviceGenerators, Namespaces, Uuid}
-import org.genivi.sota.db.SlickExtensions
-import org.genivi.sota.marshalling.CirceMarshallingSupport._
+import org.genivi.sota.data.{DeviceGenerators, Namespaces, Uuid}
 import org.genivi.sota.messaging.MessageBusPublisher
 import org.scalacheck.Gen
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.genivi.sota.marshalling.CirceInstances._
 
 import scala.concurrent.ExecutionContext
 import slick.driver.MySQLDriver.api._
@@ -36,9 +32,6 @@ class DeviceUpdatesSpec extends FunSuite
   import DeviceGenerators._
   import DeviceUpdates._
   import Generators._
-  import SlickExtensions._
-  import UpdateStatus._
-  import UpdateSpec._
 
   implicit val actorSystem = ActorSystem("InstalledPackagesUpdateSpec-ActorSystem")
   implicit val materializer = ActorMaterializer()

--- a/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/PackageUpdateSpec.scala
@@ -3,35 +3,31 @@ package org.genivi.sota.core.transfer
 import akka.actor.{ActorRef, ActorSystem}
 import akka.event.Logging
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestKit, TestProbe}
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.refineV
 import org.genivi.sota.core.Generators.updateRequestGen
 import org.genivi.sota.core._
-import org.genivi.sota.core.data.{Package, UpdateRequest, UpdateSpec}
+import org.genivi.sota.core.data.{UpdateRequest, UpdateSpec}
 import org.genivi.sota.core.db.Packages
 import org.genivi.sota.core.jsonrpc.HttpTransport
-import org.genivi.sota.core.resolver.DefaultExternalResolverClient
 import org.genivi.sota.core.rvi._
 import org.genivi.sota.data._
 import java.time.{Duration, Instant}
 import java.util.UUID
 
 import cats.data.Xor
-import org.genivi.sota.messaging.{MessageBus, MessageBusPublisher}
+import org.genivi.sota.messaging.MessageBus
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.concurrent.ScalaFutures.{PatienceConfig, convertScalaFuture, whenReady}
+import org.scalatest.concurrent.ScalaFutures.{PatienceConfig, convertScalaFuture}
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, Matchers, PropSpec}
 
 import scala.concurrent.{Await, ExecutionContext, Future}
-import slick.jdbc.JdbcBackend.Database
 
 
 /**
@@ -74,7 +70,6 @@ object SotaClient {
   import org.genivi.sota.marshalling.CirceInstances._
 
   import Arbitrary._
-  import DeviceGenerators._
   import UuidGenerator._
 
   class ClientActor(rviClient: ConnectivityClient, clientServices: ClientServices) extends Actor with ActorLogging {
@@ -167,8 +162,7 @@ object SotaClient {
 trait SotaCore {
   self: DatabaseSpec =>
 
-  import org.genivi.sota.core.rvi.{TransferProtocolActor, PackageTransferActor,
-    UpdateController, JsonRpcRviClient, RviConnectivity}
+  import org.genivi.sota.core.rvi.{TransferProtocolActor, PackageTransferActor, UpdateController, RviConnectivity}
 
   implicit val system = akka.actor.ActorSystem("PackageUpdateSpec")
   implicit val materializer = akka.stream.ActorMaterializer()
@@ -207,8 +201,6 @@ class PackageUpdateSpec extends PropSpec
   with Namespaces {
 
   import DataGenerators._
-  import DeviceGenerators._
-  import UuidGenerator._
 
   override def beforeAll() : Unit = {
     super.beforeAll()
@@ -218,7 +210,6 @@ class PackageUpdateSpec extends PropSpec
 
   def init(services: ServerServices,
            generatedData: Map[UpdateRequest, UpdateService.DeviceToPackageIds]): Future[Set[UpdateSpec]] = {
-    import slick.driver.MySQLDriver.api._
 
     implicit val _db = db
 

--- a/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/transfer/UpdateNotifierSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.Future
 object UpdateNotifierSpec {
 
   import Arbitrary._
-  import Generators.{dependenciesGen, updateRequestGen, vinDepGen}
+  import Generators.updateRequestGen
   import UuidGenerator._
 
   val packages = scala.util.Random.shuffle( PackagesReader.read().take(100) )
@@ -48,8 +48,6 @@ class UpdateNotifierSpec extends PropSpec
   with Namespaces {
 
   import UpdateNotifierSpec._
-  import DeviceGenerators._
-  import UuidGenerator._
 
   implicit val system = akka.actor.ActorSystem("UpdateServiseSpec")
   implicit val materilizer = akka.stream.ActorMaterializer()

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -122,7 +122,7 @@ object SotaBuild extends Build {
     .settings(mainClass in Compile := Some("org.genivi.sota.resolver.Boot"))
 
   lazy val core = Project(id = "sota-core", base = file("core"))
-    .settings( commonSettings ++ Migrations.settings ++ Seq(
+    .settings( commonSettings ++ Migrations.settings ++ lintOptions ++ Seq(
       libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.Scalaz :+ Dependencies.Flyway :+ Dependencies.AmazonS3,
       testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi", "-l", "IntegrationTest"),
       testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi", "-n", "IntegrationTest"),


### PR DESCRIPTION
Notice this one contains two changes which are not just imports:

In TransferController a ```map``` is changed to a ```collect``` because the function is not total.

In db/Campaigns ```.?``` is used because the implicit trait that was used before is deprecated.