### PR TITLE
[PRO-1956] map a package to a list of devices

### DIFF
--- a/core/src/main/resources/db/migration/V27__add_auto_install.sql
+++ b/core/src/main/resources/db/migration/V27__add_auto_install.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `AutoInstall` (
+  `namespace` char(200) NOT NULL,
+  `pkg_name` varchar(200) NOT NULL,
+  `device` char(36) NOT NULL,
+
+  PRIMARY KEY (namespace, pkg_name, device)
+);

--- a/core/src/main/scala/org/genivi/sota/core/AutoInstallResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/AutoInstallResource.scala
@@ -1,0 +1,103 @@
+/**
+  * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+  * License: MPL-2.0
+  */
+package org.genivi.sota.core
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.AuthorizationFailedRejection
+import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.Directive1
+import akka.http.scaladsl.server.Route
+import akka.stream.ActorMaterializer
+
+import eu.timepit.refined.api.Refined
+
+import org.genivi.sota.common.DeviceRegistry
+import org.genivi.sota.core.db.AutoInstalls
+import org.genivi.sota.data.Namespace
+import org.genivi.sota.data.PackageId
+import org.genivi.sota.data.Uuid
+import org.genivi.sota.device_registry.common.{Errors => DeviceRegistryErrors}
+import org.genivi.sota.http.AuthedNamespaceScope
+import org.genivi.sota.http.ErrorHandler
+import org.genivi.sota.http.Scopes
+import org.genivi.sota.http.UuidDirectives.extractUuid
+import org.genivi.sota.marshalling.CirceMarshallingSupport
+import org.genivi.sota.marshalling.RefinedMarshallingSupport._
+
+import scala.concurrent.ExecutionContext
+
+import slick.driver.MySQLDriver.api.Database
+
+class AutoInstallResource
+  (db: Database, deviceRegistry: DeviceRegistry, namespaceExtractor: Directive1[AuthedNamespaceScope])
+  (implicit system: ActorSystem, mat: ActorMaterializer, ec: ExecutionContext) extends Directives {
+  import CirceMarshallingSupport._
+
+  def deviceAllowed(uuid: Uuid, ns: AuthedNamespaceScope): Directive1[Uuid] = {
+    import scala.util.{Success, Failure}
+    val f = deviceRegistry.fetchDevice(ns, uuid)
+    onComplete(f) flatMap {
+      case Success(device) => provide(uuid)
+      case Failure(DeviceRegistryErrors.MissingDevice) => complete(DeviceRegistryErrors.MissingDevice)
+      case Failure(t) => reject(AuthorizationFailedRejection)
+    }
+  }
+
+  def devicePathExtractor(ns: AuthedNamespaceScope): Directive1[Uuid] = extractUuid.flatMap { uuid =>
+    deviceAllowed(uuid, ns)
+  }
+
+  def deviceQueryExtractor(ns: AuthedNamespaceScope): Directive1[Uuid] =
+    parameter('device.as[Refined[String, Uuid.Valid]]).flatMap { uuid =>
+      deviceAllowed(Uuid(uuid), ns)
+    }
+
+  def listDevice(ns: Namespace, pkgName: PackageId.Name): Route = {
+    complete(db.run(AutoInstalls.listDevices(ns, pkgName)))
+  }
+
+  def listPackages(ns: Namespace, device: Uuid): Route = {
+    complete(db.run(AutoInstalls.listPackages(ns, device)))
+  }
+
+  def removeAll(ns: Namespace, pkgName: PackageId.Name): Route = {
+    complete(db.run(AutoInstalls.removeAll(ns, pkgName)))
+  }
+
+  def addDevice(ns: Namespace, pkgName: PackageId.Name, dev: Uuid): Route = {
+    complete(db.run(AutoInstalls.addDevice(ns, pkgName, dev)))
+  }
+
+  def removeDevice(ns: Namespace, pkgName: PackageId.Name, dev: Uuid): Route = {
+    complete(db.run(AutoInstalls.removeDevice(ns, pkgName, dev)))
+  }
+
+  val route = ErrorHandler.handleErrors {
+    (pathPrefix("auto_install") & namespaceExtractor) { ns =>
+      val scope = Scopes.updates(ns)
+      (pathEnd & scope.get & deviceQueryExtractor(ns)) { uuid =>
+        listPackages(ns, uuid)
+      } ~
+      PackagesResource.extractPackageName { pkgName =>
+        pathEnd {
+          scope.get {
+            listDevice(ns, pkgName)
+          } ~
+          scope.delete {
+            removeAll(ns, pkgName)
+          }
+        } ~
+        devicePathExtractor(ns) { devUuid =>
+          scope.put {
+            addDevice(ns, pkgName, devUuid)
+          } ~
+          scope.delete {
+            removeDevice(ns, pkgName, devUuid)
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
+++ b/core/src/main/scala/org/genivi/sota/core/PackagesResource.scala
@@ -40,13 +40,16 @@ import org.genivi.sota.http.Errors.RawError
 import scala.concurrent.Future
 
 object PackagesResource {
+
+  val extractPackageName: Directive1[PackageId.Name] =
+    refined[PackageId.ValidName](Slash ~ Segment)
+
   /**
     * A scala HTTP routing directive that extracts a package name/version from
     * the request URL
     */
-  val extractPackageId: Directive1[PackageId] = (
-    refined[PackageId.ValidName](Slash ~ Segment) &
-      refined[PackageId.ValidVersion](Slash ~ Segment)).as(PackageId.apply _)
+  val extractPackageId: Directive1[PackageId] =
+    (extractPackageName & refined[PackageId.ValidVersion](Slash ~ Segment)).as(PackageId.apply _)
 }
 
 class PackagesResource(resolver: ExternalResolverClient, db : Database,

--- a/core/src/main/scala/org/genivi/sota/core/WebService.scala
+++ b/core/src/main/scala/org/genivi/sota/core/WebService.scala
@@ -31,6 +31,7 @@ class WebService(notifier: UpdateNotifier,
 
   val devicesResource = new DevicesResource(db, connectivity.client, resolver, deviceRegistry, authNamespace)
   val packagesResource = new PackagesResource(resolver, db, messageBusPublisher, authNamespace)
+  val autoInstallResource = new AutoInstallResource(db, deviceRegistry, authNamespace)
   val updateService = new UpdateService(notifier, deviceRegistry)
   val updateRequestsResource = new UpdateRequestsResource(db, resolver, updateService, authNamespace)
   val historyResource = new HistoryResource(authNamespace)(db, system)
@@ -42,6 +43,7 @@ class WebService(notifier: UpdateNotifier,
     campaignResource.route ~
     devicesResource.route ~
     packagesResource.route ~
+    autoInstallResource.route ~
     updateRequestsResource.route ~
     historyResource.route ~
     blacklistResource.route ~

--- a/core/src/main/scala/org/genivi/sota/core/data/AutoInstall.scala
+++ b/core/src/main/scala/org/genivi/sota/core/data/AutoInstall.scala
@@ -1,0 +1,11 @@
+/**
+  * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+  * License: MPL-2.0
+  */
+package org.genivi.sota.core.data
+
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
+
+case class AutoInstall(namespace: Namespace,
+                       pkgName: PackageId.Name,
+                       device: Uuid)

--- a/core/src/main/scala/org/genivi/sota/core/db/AutoInstallPackages.scala
+++ b/core/src/main/scala/org/genivi/sota/core/db/AutoInstallPackages.scala
@@ -1,0 +1,59 @@
+/**
+  * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+  * License: MPL-2.0
+  */
+package org.genivi.sota.core.db
+
+import org.genivi.sota.core.data.AutoInstall
+import org.genivi.sota.data.{Namespace, PackageId, Uuid}
+import scala.concurrent.ExecutionContext
+import slick.driver.MySQLDriver.api._
+
+object AutoInstalls {
+  import org.genivi.sota.refined.SlickRefined._
+  import org.genivi.sota.db.SlickExtensions._
+
+  class AutoInstallTable(tag: Tag) extends Table[AutoInstall](tag, "AutoInstall") {
+    def namespace = column[Namespace]("namespace")
+    def pkgName = column[PackageId.Name]("pkg_name")
+    def device = column[Uuid]("device")
+
+    def pk = primaryKey("pk_auto_install", (namespace, pkgName, device))
+
+    def * = (namespace, pkgName, device).shaped <>
+      ((AutoInstall.apply _).tupled, AutoInstall.unapply)
+  }
+
+  val all = TableQuery[AutoInstallTable]
+
+  def listDevices(ns: Namespace, pkgName: PackageId.Name): DBIO[Seq[Uuid]]
+    = all.filter(_.namespace === ns)
+      .filter(_.pkgName === pkgName)
+      .map(_.device)
+      .result
+
+  def listPackages(ns: Namespace, device: Uuid): DBIO[Seq[PackageId.Name]]
+    = all.filter(_.namespace === ns)
+    .filter(_.device === device)
+    .map(_.pkgName)
+    .result
+
+  def removeAll(ns: Namespace, pkgName: PackageId.Name)
+               (implicit ec: ExecutionContext): DBIO[Unit]
+    = all.filter(_.namespace === ns)
+      .filter(_.pkgName === pkgName)
+      .delete
+      .map(_ => ())
+
+  def addDevice(ns: Namespace, pkgName: PackageId.Name, dev: Uuid)
+               (implicit ec: ExecutionContext): DBIO[Unit]
+    = all.insertOrUpdate(AutoInstall(ns, pkgName, dev)).map(_ => ())
+
+  def removeDevice(ns: Namespace, pkgName: PackageId.Name, dev: Uuid)
+                  (implicit ec: ExecutionContext): DBIO[Unit]
+    = all.filter(_.namespace === ns)
+      .filter(_.pkgName === pkgName)
+      .filter(_.device === dev)
+      .delete
+      .map(_ => ())
+}

--- a/core/src/test/scala/org/genivi/sota/core/AutoInstallResource.scala
+++ b/core/src/test/scala/org/genivi/sota/core/AutoInstallResource.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+ * License: MPL-2.0
+ */
+
+package org.genivi.sota.core
+
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes, Uri}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+
+import cats.implicits._
+
+import org.genivi.sota.data.{Namespaces, PackageId, Uuid}
+import org.genivi.sota.data.DeviceGenerators._
+import org.genivi.sota.data.GeneratorOps._
+import org.genivi.sota.http.NamespaceDirectives.defaultNamespaceExtractor
+import org.genivi.sota.marshalling.CirceMarshallingSupport._
+
+import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.concurrent.ScalaFutures
+
+class AutoInstallResourceSpec extends FunSuite
+    with ScalatestRouteTest
+    with DatabaseSpec
+    with ShouldMatchers
+    with ScalaFutures
+    with DefaultPatience
+    with Generators {
+  import Uri.{Path, Query}
+
+  val deviceRegistry = new FakeDeviceRegistry(Namespaces.defaultNs)
+
+  val service = new AutoInstallResource(db, deviceRegistry, defaultNamespaceExtractor).route
+  private val autoinstallPath = "/auto_install"
+
+  def autoinstallUrl(pathSuffixes: String*): Uri = {
+    Uri.Empty.withPath(pathSuffixes.foldLeft(Path(autoinstallPath))(_/_))
+  }
+
+  def createDevice(): Uuid = {
+    val device = genDevice.generate
+    deviceRegistry.addDevice(device)
+    device.uuid
+  }
+
+  def addDevice(pkgName: PackageId.Name, device: Uuid): HttpRequest = {
+    Put(autoinstallUrl(pkgName.get, device.show))
+  }
+
+  def listDevices(pkgName: PackageId.Name): HttpRequest = {
+    Get(autoinstallUrl(pkgName.get))
+  }
+
+  def listPackages(device: Uuid): HttpRequest = {
+    Get(autoinstallUrl().withQuery(Query("device" -> device.show)))
+  }
+
+  def removeAll(pkgName: PackageId.Name): HttpRequest = {
+    Delete(autoinstallUrl(pkgName.get))
+  }
+
+  def removeDevice(pkgName: PackageId.Name, dev: Uuid): HttpRequest = {
+    Delete(autoinstallUrl(pkgName.get, dev.show))
+  }
+
+
+  def addDeviceOk(pkgName: PackageId.Name, device: Uuid): Unit = {
+    addDevice(pkgName, device) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  def removeAllOk(pkgName: PackageId.Name): Unit = {
+    removeAll(pkgName) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  def removeDeviceOk(pkgName: PackageId.Name, device: Uuid): Unit = {
+    removeDevice(pkgName, device) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+
+  test("add device shows up in listed") {
+    val device = createDevice()
+    val pkgName = PackageNameGen.generate
+
+    addDeviceOk(pkgName, device)
+
+    listDevices(pkgName) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+      val devs = responseAs[Seq[Uuid]]
+
+      devs should contain(device)
+    }
+  }
+
+  test("can remove device") {
+    val device1 = createDevice()
+    val device2 = createDevice()
+    val pkgName = PackageNameGen.generate
+
+    addDeviceOk(pkgName, device1)
+    addDeviceOk(pkgName, device2)
+
+    listDevices(pkgName) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+      val devs = responseAs[Seq[Uuid]]
+
+      devs should contain(device1)
+    }
+
+    removeDeviceOk(pkgName, device1)
+
+    listDevices(pkgName) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+      val devs = responseAs[Seq[Uuid]]
+
+      devs should not contain(device1)
+      devs should contain(device2)
+    }
+  }
+
+  test("can remove all devices") {
+    val device1 = createDevice()
+    val device2 = createDevice()
+    val pkgName = PackageNameGen.generate
+
+    addDeviceOk(pkgName, device1)
+    addDeviceOk(pkgName, device2)
+
+    removeAllOk(pkgName)
+
+    listDevices(pkgName) ~> service ~> check {
+      status shouldBe StatusCodes.OK
+      val devs = responseAs[Seq[Uuid]]
+
+      devs shouldBe Seq()
+    }
+  }
+
+  test("can't add device that doesn't exist") {
+    val notDevice = Uuid.generate
+    val pkgName = PackageNameGen.generate
+
+    addDevice(pkgName, notDevice) ~> service ~> check {
+      status shouldBe StatusCodes.NotFound
+    }
+  }
+
+  test("query packages for device") {
+    val device = createDevice()
+    val pkgName1 = PackageNameGen.generate
+    val pkgName2 = PackageNameGen.generate
+
+    addDeviceOk(pkgName1, device)
+    addDeviceOk(pkgName2, device)
+
+    listPackages(device) ~> service ~> check {
+      val pkgs = responseAs[Seq[PackageId.Name]]
+      pkgs should contain(pkgName1)
+      pkgs should contain(pkgName2)
+    }
+
+  }
+}

--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -124,6 +124,82 @@ paths:
             type: array
             items:
               type: string
+  /auto_install:
+    get:
+      description: Return a list of packages that will update automatically for a given device uuid.
+      parameters:
+        - name: device
+          in: query
+          description: The device uuid.
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              type: string
+  /auto_install/{pkgName}:
+    get:
+      description: Return a list of device uuids that will update automatically for that package.
+      parameters:
+      - name: pkgName
+        in: path
+        description: The package name.
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              type: string
+    delete:
+      description: Remove all automatical updates for this package.
+      parameters:
+      - name: pkgName
+        in: path
+        description: The package name.
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+  /auto_install/{pkgName}/{uuid}:
+    put:
+      description: Add a device uuid to be automatically updated for this package.
+      parameters:
+      - name: pkgName
+        in: path
+        description: The package name.
+        required: true
+        type: string
+      - name: uuid
+        in: path
+        description: The device uuid.
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
+    delete:
+      description: Remove a device from being automatically updated for this package.
+      parameters:
+      - name: pkgName
+        in: path
+        description: The package name.
+        required: true
+        type: string
+      - name: uuid
+        in: path
+        description: The device uuid.
+        required: true
+        type: string
+      responses:
+        200:
+          description: OK
   /campaigns:
     get:
       description: 'List all campaigns'


### PR DESCRIPTION
Add an association between package-names and device-uuids that will be used for automatically queue installs when the package is updated (which is JIRA ticket PRO-1957)