### PR TITLE
Fix TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: false
 language: scala
 jdk:
   - oraclejdk8
@@ -8,6 +10,11 @@ services:
 before_install:
   - mkdir entrypoint.d
   - echo "CREATE DATABASE sota_resolver;CREATE DATABASE sota_resolver_test;CREATE DATABASE sota_core;CREATE DATABASE sota_core_test;GRANT ALL PRIVILEGES ON \`sota\_core%\`.* TO 'sota_test'@'%';GRANT ALL PRIVILEGES ON \`sota\_resolver%\`.* TO 'sota_test'@'%';GRANT ALL PRIVILEGES ON \`sota\_device\_registry%\`.* TO 'sota_test'@'%';FLUSH PRIVILEGES;" > entrypoint.d/db_user.sql
-  - docker run -d --name mariadb-sota -p 3306:3306 -v $(pwd)/entrypoint.d:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=sota-test -e MYSQL_USER=sota_test -e MYSQL_PASSWORD=s0ta mariadb:10.1 --character-set-server=utf8 --collation-server=utf8_unicode_ci --max_connections=1000
+  - docker run -d --name mariadb-sota -p 3307:3306 -v $(pwd)/entrypoint.d:/docker-entrypoint-initdb.d -e MYSQL_ROOT_PASSWORD=sota-test -e MYSQL_USER=sota_test -e MYSQL_PASSWORD=s0ta mariadb:10.1 --character-set-server=utf8 --collation-server=utf8_unicode_ci --max_connections=1000
+env:
+  global:
+    - RESOLVER_TEST_DB_URL="jdbc:mariadb://localhost:3307/"
+    - CORE_TEST_DB_URL="jdbc:mariadb://localhost:3307/"
+    - DEVICE_REGISTRY_TEST_DB_URL="jdbc:mariadb://localhost:3307/"
 script:
   - ./sbt coverage sota-core/ut:test sota-resolver/ut:test sota-device_registry/ut:test sota-common/test


### PR DESCRIPTION
Change MariaDB to listen on 3307, as 3306 now seems to be in use on the TravisCI instances that we're testing with.