### PR TITLE
Add migration code for installed packages

### DIFF
--- a/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/DeviceRegistry.scala
@@ -53,4 +53,7 @@ trait DeviceRegistry {
 
   def setInstalledPackages
     (device: Uuid, packages: Seq[PackageId])(implicit ec: ExecutionContext) : Future[NoContent]
+
+  def setInstalledPackagesForDevices
+    (data: Seq[(Uuid, Set[PackageId])])(implicit ec: ExecutionContext) : Future[NoContent]
 }

--- a/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
+++ b/common-client/src/main/scala/org/genivi/sota/client/DeviceRegistryClient.scala
@@ -27,6 +27,7 @@ import org.genivi.sota.http.NamespaceDirectives.nsHeader
 import org.genivi.sota.marshalling.CirceMarshallingSupport
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 
 
 class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri, deviceGroupsUri: Uri, mydeviceUri: Uri)
@@ -85,19 +86,25 @@ class DeviceRegistryClient(baseUri: Uri, devicesUri: Uri, deviceGroupsUri: Uri, 
     execHttp[NoContent](HttpRequest(method = PUT, uri = baseUri.withPath(mydeviceUri.path / uuid.show / "system_info"),
       entity = HttpEntity(ContentTypes.`application/json`, json.noSpaces)))
 
-  override def setInstalledPackages
-    (device: Uuid, packages: Seq[PackageId])(implicit ec: ExecutionContext) : Future[NoContent] =
-      execHttp[NoContent](HttpRequest(method = PUT, uri = baseUri.withPath(mydeviceUri.path / device.show / "packages"),
-        entity = HttpEntity(ContentTypes.`application/json`, packages.asJson.noSpaces)))
+  override def setInstalledPackages(device: Uuid, packages: Seq[PackageId])
+                                   (implicit ec: ExecutionContext) : Future[NoContent] =
+    execHttp[NoContent](HttpRequest(method = PUT, uri = baseUri.withPath(mydeviceUri.path / device.show / "packages"),
+      entity = HttpEntity(ContentTypes.`application/json`, packages.asJson.noSpaces)))
 
+  def setInstalledPackagesForDevices(data: Seq[(Uuid, Set[PackageId])])
+                                    (implicit ec: ExecutionContext) : Future[NoContent] =
+    execHttp[NoContent](HttpRequest(method = PUT, uri = baseUri.withPath(mydeviceUri.path / "packages"),
+      entity = HttpEntity(ContentTypes.`application/json`, data.asJson.noSpaces)))
 
   private def execHttp[T](httpRequest: HttpRequest)
                          (implicit unmarshaller: Unmarshaller[ResponseEntity, T],
-                          ec: ExecutionContext): Future[T] = {
+                          ec: ExecutionContext, ct: ClassTag[T]): Future[T] = {
     http.singleRequest(httpRequest).flatMap { response =>
       response.status match {
         case Conflict => FastFuture.failed(Errors.ConflictingDeviceId)
         case NotFound => FastFuture.failed(Errors.MissingDevice)
+        case StatusCodes.NoContent if ct.runtimeClass == classOf[NoContent] =>
+          FastFuture.successful(org.genivi.sota.client.NoContent()).asInstanceOf[Future[T]]
         case other if other.isSuccess() => unmarshaller(response.entity)
         case err => FastFuture.failed(new Exception(err.toString))
       }

--- a/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
+++ b/common-client/src/main/scala/org/genivi/sota/core/FakeDeviceRegistry.scala
@@ -134,4 +134,8 @@ class FakeDeviceRegistry(namespace: Namespace)
   def setInstalledPackages
     (device: Uuid, packages: Seq[PackageId])(implicit ec: ExecutionContext) : Future[NoContent] =
       FastFuture.successful(NoContent())
+
+  def setInstalledPackagesForDevices(data: Seq[(Uuid, Set[PackageId])])
+                                    (implicit ec: ExecutionContext) : Future[NoContent] =
+    FastFuture.successful(NoContent())
 }

--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/db/InstalledPackages.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/db/InstalledPackages.scala
@@ -53,6 +53,9 @@ object InstalledPackages {
       installedPackages ++= packages.map(InstalledPackage(device, _, Instant.now()))
     ).transactionally
 
+  def setInstalledForDevices(data: Seq[(Uuid, Seq[PackageId])])(implicit ec: ExecutionContext): DBIO[Unit] =
+    DBIO.seq(data.map(devicePkgs => setInstalled(devicePkgs._1, devicePkgs._2.toSet)): _*).transactionally
+
   def installedOn(device: Uuid)(implicit ec: ExecutionContext): DBIO[Seq[InstalledPackage]] =
     installedPackages
       .filter(_.device === device)

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/Boot.scala
@@ -95,6 +95,9 @@ object Boot extends BootApp with Directives with BootMigrations
       }
     }
 
+  if(sys.env.get("RESOLVER_DEVICE_MIGRATE").contains("true")) {
+    DeviceDataMigrator(deviceRegistryClient)
+  }
 
   val messageBusListener = system.actorOf(PackageCreatedListener.props(db, system.settings.config))
   messageBusListener ! Subscribe

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/DeviceDataMigrator.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/DeviceDataMigrator.scala
@@ -1,0 +1,39 @@
+package org.genivi.sota.resolver
+
+import java.time.Instant
+
+import org.genivi.sota.common.DeviceRegistry
+import org.genivi.sota.data.{PackageId, Uuid}
+import org.genivi.sota.resolver.db.ForeignPackages.InstalledForeignPackage
+import org.genivi.sota.resolver.db.{DeviceRepository, ForeignPackages}
+import org.slf4j.LoggerFactory
+import slick.driver.MySQLDriver.api._
+
+import scala.collection.mutable
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+
+object DeviceDataMigrator {
+
+  private lazy val logger = LoggerFactory.getLogger(this.getClass)
+
+  def apply(deviceRegistry: DeviceRegistry)(implicit db: Database, ec: ExecutionContext): Unit = {
+    val f = for {
+      rows          <- db.run(packages())
+      pkgsPerDevice = mutable.Map[Uuid, Set[PackageId]]()
+      _             = rows.foreach { elem =>
+                        pkgsPerDevice(elem.device) = pkgsPerDevice.getOrElse(elem.device, Set()) + elem.packageId
+                      }
+      _             <- deviceRegistry.setInstalledPackagesForDevices(pkgsPerDevice.toSeq)
+    } yield ()
+    Await.result(f, 3.minutes)
+  }
+
+  def packages()(implicit db: Database, ec: ExecutionContext): DBIO[Seq[InstalledForeignPackage]] =
+    for {
+      nonForeignPkgRows <- DeviceRepository.listInstalledPackages
+      now               = Instant.now()
+      nonForeignPkgs    = nonForeignPkgRows.map{ r => InstalledForeignPackage(r._2, r._3, now) }
+      foreignPkgs       <- ForeignPackages.listPackages
+    } yield foreignPkgs ++ nonForeignPkgs
+}

--- a/external-resolver/src/main/scala/org/genivi/sota/resolver/db/ForeignPackages.scala
+++ b/external-resolver/src/main/scala/org/genivi/sota/resolver/db/ForeignPackages.scala
@@ -74,6 +74,10 @@ object ForeignPackages {
       .result.map(_.map(_.packageId))
   }
 
+  def listPackages: DBIO[Seq[InstalledForeignPackage]] =
+    foreignPackages
+      .result
+
   //scalastyle: off
   private def inSetQuery(ids: Set[PackageId]): Query[InstalledForeignPackageTable, InstalledForeignPackage, Seq] = {
     foreignPackages


### PR DESCRIPTION
 - PRO-2111
 - Add method to move data on software installed on devices from
   resolver to device registry.
 - Had to add additional endpoint to work around deadlock bug in slick.