### PR TITLE
[PRO-2206] The wrong namespace in DeviceSeen

### DIFF
--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/SystemInfoResource.scala
@@ -64,7 +64,7 @@ class SystemInfoResource(authNamespace: Directive1[AuthedNamespaceScope],
       }
     }
 
-  def mydeviceRoutes: Route = authNamespace { authedNs =>
+  def mydeviceRoutes: Route = authNamespace { authedNs => // don't use this as a namespace
     (pathPrefix("mydevice") & extractUuid) { uuid =>
       (put & path("system_info") & authedNs.oauthScope(s"ota-core.{uuid.show}.write")) {
         entity(as[Json]) { body => updateSystemInfo(uuid, body) }

--- a/device-registry/src/test/scala/org/genivi/sota/device_registry/db/DeviceRepositorySpec.scala
+++ b/device-registry/src/test/scala/org/genivi/sota/device_registry/db/DeviceRepositorySpec.scala
@@ -27,8 +27,8 @@ class DeviceRepositorySpec extends FunSuite
     val device = genDeviceT.sample.get.copy(deviceId = Some(genDeviceId.sample.get))
     val setTwice = for {
       uuid <- DeviceRepository.create(Namespaces.defaultNs, device)
-      first <- DeviceRepository.updateLastSeen(uuid, Instant.now())
-      second <- DeviceRepository.updateLastSeen(uuid, Instant.now())
+      first <- DeviceRepository.updateLastSeen(uuid, Instant.now()).map(_._1)
+      second <- DeviceRepository.updateLastSeen(uuid, Instant.now()).map(_._1)
     } yield (first, second)
 
     whenReady(db.run(setTwice), Timeout(Span(10, Seconds))) {


### PR DESCRIPTION
/mydevice routes should not use the namespace from the extractor as the
real namespace (since it is the ClientId of the device). This meant that
the wrong namespace was used in the DeviceSeen event.