### PR TITLE
remove flag

### DIFF
--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -52,7 +52,6 @@ object SotaBuild extends Build {
   lazy val lintOptions = Seq(
     scalacOptions in Compile ++= Seq(
       "-Ywarn-unused-import",
-      "-Xfatal-warnings",
       "-Xlint:-missing-interpolator",
       "-Ywarn-dead-code",
       "-Yno-adapted-args"


### PR DESCRIPTION
At least one of these have to go:

```
      "-Ywarn-unused-import",
      "-Xfatal-warnings",
```

This makes it impossible to run sbt/console for example. It makes developing slower,  commenting code temporarily for debugging requires you to go back and remove all the imports for that code.