### PR TITLE
Change LDAP scope from ONE to SUB

### DIFF
--- a/web-server/app/org/genivi/webserver/Authentication/LdapAuth.scala
+++ b/web-server/app/org/genivi/webserver/Authentication/LdapAuth.scala
@@ -113,7 +113,7 @@ class LdapAuth @Inject() (config: Configuration, lifecicle: ApplicationLifecycle
 
   private[this] def findUser(baseDN: String, filter: String, userName: String): Future[SearchResult] =
     Future {
-      ldap.search(baseDN, SearchScope.ONE, filter.format(userName))
+      ldap.search(baseDN, SearchScope.SUB, filter.format(userName))
     }
 
   private[this] def bind(dn: String, password: String): Future[NotUsed] = Future {


### PR DESCRIPTION
To find the users on the genivi LDAP server, it needs to so a subtree search rather than just the scope ONE search.