### PR TITLE
fix treehub package hash to be the commit hash

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/daemon/TreehubCommitListener.scala
+++ b/core/src/main/scala/org/genivi/sota/core/daemon/TreehubCommitListener.scala
@@ -6,22 +6,16 @@ package org.genivi.sota.core.daemon
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
 import cats.syntax.show._
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
 import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HashMethod, ValidChecksum}
 import com.advancedtelematic.libtuf.reposerver.ReposerverClient
 import java.util.UUID
-import org.genivi.sota.core.DigestCalculator.DigestResult
 import org.genivi.sota.core.Settings
 import org.genivi.sota.core.UpdateService
 import org.genivi.sota.core.data.Package
-import org.genivi.sota.core.storage.PackageStorage
-import org.genivi.sota.core.storage.PackageStorage.{PackageSize, PackageStorageOp}
 import org.genivi.sota.core.storage.StoragePipeline
 import org.genivi.sota.data.PackageId
 import org.genivi.sota.messaging.MessageBusPublisher
@@ -49,35 +43,25 @@ class TreehubCommitListener(db: Database,
   implicit val _bus = bus
   val log = LoggerFactory.getLogger(this.getClass)
 
-  val packageStorageOp: PackageStorageOp = new PackageStorage().store _
-  lazy val storagePipeline = new StoragePipeline(updateService, packageStorageOp)
+  lazy val storagePipeline = new StoragePipeline(updateService)
 
   def action(event: TreehubCommit)
             (implicit ec: ExecutionContext): Future[Done] = for {
     pid  <- Future.fromTry(mkPkgId(event))
-    _    <- storagePipeline.storePackage(event.ns, pid, mkPayload(event, pid), mkPkg(event, pid))
+    pkg   = mkPkg(event, pid)
+    _    <- storagePipeline.storePackage(pkg)
     _    <- publishToTuf(event, pid)
   } yield Done
 
   /***************************************************************************/
 
   def mkPkgId(event: TreehubCommit): Try[PackageId] = for {
-    n <- (s"treehub-${event.refName}").refineTry[PackageId.ValidName]
+    n <- (event.refName).refineTry[PackageId.ValidName]
     v <- (event.commit).refineTry[PackageId.ValidVersion]
   } yield PackageId(n, v)
 
-  def mkPkg(event: TreehubCommit, pid: PackageId)
-           (uri: Uri, _size: PackageSize, digest: DigestResult): Package =
-      Package(event.ns, UUID.randomUUID(), pid, uri, event.size, digest, Some(event.description), None, None)
-
-  def mkPayload(event: TreehubCommit, pid: PackageId): Source[ByteString, Any] = {
-    import io.circe.generic.auto._
-    import io.circe.syntax._
-
-    val payload = ImageRequest(event.commit, event.refName, event.description, event.uri).asJson.noSpaces
-
-    Source(Vector(ByteString(payload)))
-  }
+  def mkPkg(event: TreehubCommit, pid: PackageId): Package =
+      Package(event.ns, UUID.randomUUID(), pid, event.uri, event.size, event.commit, Some(event.description), None, None)
 
   def publishToTuf(event: TreehubCommit, pid: PackageId): Future[Unit] = for {
     hash <- Future.fromTry(event.commit.refineTry[ValidChecksum])

--- a/core/src/main/scala/org/genivi/sota/core/storage/StoragePipline.scala
+++ b/core/src/main/scala/org/genivi/sota/core/storage/StoragePipline.scala
@@ -5,44 +5,31 @@
 package org.genivi.sota.core.storage
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
 import java.time.Instant
-import org.genivi.sota.core.DigestCalculator.DigestResult
 import org.genivi.sota.core.UpdateService
 import org.genivi.sota.core.autoinstall.AutoInstall
 import org.genivi.sota.core.data.Package
 import org.genivi.sota.core.db.Packages
-import org.genivi.sota.core.storage.PackageStorage.{PackageSize, PackageStorageOp}
-import org.genivi.sota.data.Namespace
-import org.genivi.sota.data.PackageId
 import org.genivi.sota.messaging.MessageBusPublisher
 import org.genivi.sota.messaging.Messages._
 import scala.concurrent.{Future, ExecutionContext}
 import slick.driver.MySQLDriver.api.Database
 
-class StoragePipeline(updateService: UpdateService, packageStorageOp: PackageStorageOp)
+class StoragePipeline(updateService: UpdateService)
                      (implicit ec: ExecutionContext, db: Database,
                       system: ActorSystem, mat: ActorMaterializer,
                       bus: MessageBusPublisher) {
 
   implicit val _config = system.settings.config
 
-  def storePackage(ns: Namespace,
-                   pid: PackageId,
-                   file: Source[ByteString, Any],
-                   mkPkgFn: (Uri, PackageSize, DigestResult) => Package)
-                   : Future[Unit] = {
+  def storePackage(pkg: Package): Future[Unit] = {
 
     for {
-      (uri, size, digest) <- packageStorageOp(pid, ns.get, file)
-      pkg    = mkPkgFn(uri, size, digest)
       usage <- db.run(Packages.create(pkg).andThen(Packages.usage(pkg.namespace)))
       _     <- AutoInstall.packageCreated(pkg.namespace, pkg.id, updateService)
       _     <- bus.publishSafe(PackageCreated(pkg.namespace, pkg.id, pkg.description, pkg.vendor, pkg.signature))
-      _     <- bus.publishSafe(PackageStorageUsage(ns, Instant.now, usage))
+      _     <- bus.publishSafe(PackageStorageUsage(pkg.namespace, Instant.now, usage))
     } yield ()
   }
 


### PR DESCRIPTION
- get rid of treehub prefix on v3 treehub packages
- use uri from treehub commit event
- do not publish treehub packages to s3