### PR TITLE
change encoding of the uri in CampaignLaunched to just be as simple string

### DIFF
--- a/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
+++ b/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
@@ -26,6 +26,15 @@ object Messages {
 
   val partitionPrefixSize = 256
 
+  final case class UriWithSimpleEncoding(uri: Uri)
+
+  object UriWithSimpleEncoding {
+    implicit val uriWithSimpleEncoding: Encoder[UriWithSimpleEncoding] =
+      Encoder[String].contramap(_.uri.toString)
+    implicit val uriWithSimpleDecoding: Decoder[UriWithSimpleEncoding] =
+      Decoder[String].map(Uri.apply).map(UriWithSimpleEncoding.apply)
+  }
+
   final case class DeviceSeen(
     namespace: Namespace,
     uuid: Uuid,
@@ -95,8 +104,9 @@ object Messages {
                                       device: Uuid,
                                       status: DeviceStatus) extends BusMessage
 
-  final case class CampaignLaunched(namespace: Namespace, updateId: Uuid, devices: Set[Uuid], pkgUri: Uri,
-                                    pkg: PackageId, pkgSize: Long, pkgChecksum: String) extends BusMessage
+  final case class CampaignLaunched(namespace: Namespace, updateId: Uuid, devices: Set[Uuid],
+                                    pkgUri: UriWithSimpleEncoding, pkg: PackageId,
+                                    pkgSize: Long, pkgChecksum: String) extends BusMessage
 
   implicit class StreamNameOp[T <: Class[_]](v: T) {
     def streamName: String = {

--- a/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignLauncher.scala
+++ b/core/src/main/scala/org/genivi/sota/core/campaigns/CampaignLauncher.scala
@@ -12,7 +12,7 @@ import org.genivi.sota.core.data.{Campaign, UpdateRequest}
 import org.genivi.sota.core.db.{Campaigns, Packages, UpdateSpecs}
 import org.genivi.sota.data.{Interval, Namespace, PackageId, Uuid}
 import org.genivi.sota.messaging.MessageBusPublisher
-import org.genivi.sota.messaging.Messages.CampaignLaunched
+import org.genivi.sota.messaging.Messages.{CampaignLaunched, UriWithSimpleEncoding}
 import org.slf4j.LoggerFactory
 import slick.driver.MySQLDriver.api._
 
@@ -47,7 +47,8 @@ object CampaignLauncher {
     import scala.async.Async._
     async {
       val pkg = await(db.run(Packages.byId(namespace, pkgId)))
-      val msg = CampaignLaunched(namespace, updateId, devices, pkg.uri, pkgId, pkg.size, pkg.checkSum)
+      val msg = CampaignLaunched(namespace, updateId, devices, UriWithSimpleEncoding(pkg.uri),
+                                 pkgId, pkg.size, pkg.checkSum)
       await(messageBus.publish(msg))
     }
   }


### PR DESCRIPTION
I did not make it `extends AnyVal` since then it would not pick up my encoder/decoder but instead use the one from CirceInstances (or at least that is what I think happend).

Also name and place suggestions are welcome.