### PR TITLE
Exclude heathchecks from tracing

### DIFF
--- a/device-registry/src/main/scala/org/genivi/sota/device_registry/Boot.scala
+++ b/device-registry/src/main/scala/org/genivi/sota/device_registry/Boot.scala
@@ -79,9 +79,8 @@ object Boot extends BootApp with Directives with BootMigrations
     (TraceId.withTraceId &
       logResponseMetrics("device-registry", TraceId.traceMetrics) &
       versionHeaders(version)) {
-      new DeviceRegistryRoutes(authNamespace, namespaceAuthorizer, messageBus).route ~
-      new HealthResource(db, versionMap).route
-    }
+      new DeviceRegistryRoutes(authNamespace, namespaceAuthorizer, messageBus).route
+    } ~ new HealthResource(db, versionMap).route
 
   val updateSpecListener =
     system.actorOf(MessageListener.props[UpdateSpec](system.settings.config,


### PR DESCRIPTION
Log gets polluted with logging of health checks. IMO it gives us no useful information and makes hard to find valuable log entries