### PR TITLE
PRO-2845 Re-order swagger definitions section to make v3.0 UI happy

### DIFF
--- a/docs/swagger/sota-core.yml
+++ b/docs/swagger/sota-core.yml
@@ -223,7 +223,7 @@ paths:
         201:
           description: The new uuid of the created campaign
           schema:
-            $ref: '#/definitions/uuid'
+            $ref: '#/definitions/Strings/properties/uuid'
   /campaigns/{uuid}:
     get:
       description: 'Get a campaign from uuid'
@@ -756,34 +756,19 @@ paths:
           description: OK
 
 definitions:
-  uuid:
-    type: string
-    description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
-  namespace:
-    type: string
-    description: The namespace scope of the request. Default value is 'default'
-  DeviceId:
-    type: string
-    description: A 17-digit VIN. May contain only capital letters and digits. Cannot contain the letters I, O, or Q.
-  DeviceName:
-    type: string
-    description: Custom name for a device
-  DeviceType:
-    type: string
-    description: Valid values are "Vehicle" and "Other"
   Device:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       deviceId:
-        $ref: '#/definitions/DeviceId'
+        $ref: '#/definitions/Strings/properties/DeviceId'
       id:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       deviceName:
-        $ref: '#/definitions/DeviceName'
+        $ref: '#/definitions/Strings/properties/DeviceName'
       deviceType:
-        $ref: '#/definitions/DeviceType'
+        $ref: '#/definitions/Strings/properties/DeviceType'
       lastseen:
         type: string
         format: dateTime
@@ -792,7 +777,7 @@ definitions:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       id:
         $ref: '#/definitions/packageId'
       uri:
@@ -839,7 +824,7 @@ definitions:
         type: string
         description: The UUID of the update
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       packageId:
         $ref: '#/definitions/packageId'
       creationTime:
@@ -915,9 +900,9 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       packageId:
         $ref: '#/definitions/packageId'
       comment:
@@ -951,7 +936,7 @@ definitions:
     type: object
     properties:
       id:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       launched:
         type: boolean
         description: Is this campaign launched
@@ -978,9 +963,9 @@ definitions:
     type: object
     properties:
       group:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       updateRequest:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
   LaunchCampaign:
     type: object
     properties:
@@ -1010,15 +995,15 @@ definitions:
       groups:
         type: array
         items:
-          $ref: '#/definitions/uuid'
+          $ref: '#/definitions/Strings/properties/uuid'
         description: The uuids of the groups for the campaign
   CampaignStatistics:
     type: object
     properties:
       groupId:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       updateId:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       deviceCount:
         type: integer
         description: Number of devices in group
@@ -1040,4 +1025,23 @@ definitions:
     description: |
       This is a free-form JSON blob describing the hardware components of the client system. 
       The format expected by the server is the output of `lshw -json -sanitize`.
+  Strings:
+    type: object
+    description: Various string types referenced elsewhere in the spec.
+    properties:
+      uuid:
+        type: string
+        description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
+      namespace:
+        type: string
+        description: The namespace scope of the request. Default value is 'default'
+      DeviceId:
+        type: string
+        description: A 17-digit VIN. May contain only capital letters and digits. Cannot contain the letters I, O, or Q.
+      DeviceName:
+        type: string
+        description: Custom name for a device
+      DeviceType:
+        type: string
+        description: Valid values are "Vehicle" and "Other"
 

--- a/docs/swagger/sota-device_registry.yml
+++ b/docs/swagger/sota-device_registry.yml
@@ -187,7 +187,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/uuid'
+              $ref: '#/definitions/Strings/properties/uuid'
   /device_groups:
     get:
       description: Returns a list of all groups
@@ -249,7 +249,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/uuid'
+              $ref: '#/definitions/Strings/properties/uuid'
   /device_groups/{uuid}/count:
     get:
       description: return count of devices in group
@@ -367,43 +367,28 @@ paths:
               $ref: '#/definitions/PackageStat'
 
 definitions:
-  uuid:
-    type: string
-    description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
-  DeviceId:
-    type: string
-    description: A 17-digit VIN. May contain only capital letters and digits. Cannot contain the letters I, O, or Q.
-  DeviceName:
-    type: string
-    description: Custom name for a device
-  DeviceType:
-    type: string
-    description: Valid values are "Vehicle" and "Other"
-  namespace:
-    type: string
-    description: The namespace scope of the request. Default value is 'default'
   DeviceT:
     type: object
     properties:
       deviceName:
-        $ref: '#/definitions/DeviceName'
+        $ref: '#/definitions/Strings/properties/DeviceName'
       deviceId:
-        $ref: '#/definitions/DeviceId'
+        $ref: '#/definitions/Strings/properties/DeviceId'
       deviceType:
-        $ref: '#/definitions/DeviceType'
+        $ref: '#/definitions/Strings/properties/DeviceType'
   Device:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       deviceId:
-        $ref: '#/definitions/DeviceId'
+        $ref: '#/definitions/Strings/properties/DeviceId'
       id:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       deviceName:
-        $ref: '#/definitions/DeviceName'
+        $ref: '#/definitions/Strings/properties/DeviceName'
       deviceType:
-        $ref: '#/definitions/DeviceType'
+        $ref: '#/definitions/Strings/properties/DeviceType'
       lastseen:
         type: string
         format: dateTime
@@ -423,9 +408,9 @@ definitions:
     type: object
     properties:
       device1:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       device2:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       groupName:
         type: string
         description: a group name between 1 and 100 characters long
@@ -442,7 +427,7 @@ definitions:
     type: object
     properties:
       device:
-        $ref: '#/definitions/uuid'
+        $ref: '#/definitions/Strings/properties/uuid'
       packageId:
         $ref: '#/definitions/PackageId'
       lastModified:
@@ -459,7 +444,7 @@ definitions:
         description: a set containing all the group ids that have this package installed
         type: array
         items:
-          $ref: '#/definitions/uuid'
+          $ref: '#/definitions/Strings/properties/uuid'
   ActiveDeviceCount:
     type: object
     properties:
@@ -474,3 +459,22 @@ definitions:
         type: string
       installedCount:
         type: integer
+  Strings:
+    type: object
+    description: Various string types referenced elsewhere in the spec.
+    properties:
+      uuid:
+        type: string
+        description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
+      DeviceId:
+        type: string
+        description: A 17-digit VIN. May contain only capital letters and digits. Cannot contain the letters I, O, or Q.
+      DeviceName:
+        type: string
+        description: Custom name for a device
+      DeviceType:
+        type: string
+        description: Valid values are "Vehicle" and "Other"
+      namespace:
+        type: string
+        description: The namespace scope of the request. Default value is 'default'

--- a/docs/swagger/sota-resolver.yml
+++ b/docs/swagger/sota-resolver.yml
@@ -26,7 +26,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/uuid'
+              $ref: '#/definitions/Strings/properties/uuid'
   /devices/{uuid}/package:
     get:
       description: Return a list of packages installed on the device.
@@ -438,17 +438,11 @@ paths:
 
 
 definitions:
-  uuid:
-    type: string
-    description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
-  namespace:
-    type: string
-    description: The namespace scope of the request. Default value is 'default'
   resolverPackage:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       id:
         $ref: '#/definitions/packageId'
       description:
@@ -470,7 +464,7 @@ definitions:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       partNumber:
         type: string
         description: A part number uniquely identifying the component.
@@ -485,7 +479,7 @@ definitions:
     type: object
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       name:
         type: string
         description: The filter's name.
@@ -497,7 +491,7 @@ definitions:
     description: An association between a package and a filter.
     properties:
       namespace:
-        $ref: '#/definitions/namespace'
+        $ref: '#/definitions/Strings/properties/namespace'
       packageName:
         type: string
       packageVersion:
@@ -521,4 +515,14 @@ definitions:
       lastModified:
         type: string
         format: dateTime
+  Strings:
+    type: object
+    description: Various string types referenced elsewhere in the spec.
+    properties:
+      uuid:
+        type: string
+        description: 32 lowercase hexadecimal digits, displayed in five groups separated by hyphens
+      namespace:
+        type: string
+        description: The namespace scope of the request. Default value is 'default'
 


### PR DESCRIPTION
Purely cosmetic. The new version of the Swagger UI shows the model definitions, which is handy. Unfortunately, it only does this for objects of type 'object'. This change just dumps all the different kinds of string we defined into one object, and changes the references accordingly, so that the UI properly displays them.