### PR TITLE
Log errors and continue when receiving delta messages

### DIFF
--- a/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
+++ b/common-messaging/src/main/scala/org/genivi/sota/messaging/Messages.scala
@@ -115,7 +115,7 @@ object Messages {
   final case class DeltaRequest(id: Uuid, namespace: Namespace, from: Commit, to: Commit,
                                 timestamp: Instant = Instant.now) extends BusMessage
 
-  final case class GeneratedDelta(id: Uuid, namespace: Namespace, from: Commit, to: Commit, uri: Uri, size: Long)
+  final case class GeneratedDelta(id: Uuid, namespace: Namespace, from: Commit, to: Commit, size: Long)
     extends BusMessage
 
   final case class DeltaGenerationFailed(id: Uuid, namespace: Namespace, error: Option[Json] = None) extends BusMessage

--- a/core/src/test/scala/org/genivi/sota/core/CampaignResourceSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/CampaignResourceSpec.scala
@@ -392,7 +392,7 @@ class CampaignResourceSpec extends FunSuite
     val fromCommit: Commit = Refined.unsafeApply("c62ede9bdc7b53f7497e98af4381f95fde24667fc829aea8d933b70afedb7a0a")
     val toCommit: Commit = Refined.unsafeApply("c62ede9bdc7b53f7497e98af4381f95fde24667fc829aea8d933b70afedb7a0b")
     val size = 100
-    val msg = GeneratedDelta(campaign.meta.id.underlying, Namespaces.defaultNs, fromCommit, toCommit, Uri(), size)
+    val msg = GeneratedDelta(campaign.meta.id.underlying, Namespaces.defaultNs, fromCommit, toCommit, size)
     new DeltaListener(deviceRegistry, updateService, messageBus).generatedDeltaAction(msg).futureValue
     val camp = fetchCampaignOk(campaign.meta.id)
     camp.meta.status shouldBe CampaignStatus.Active

--- a/core/src/test/scala/org/genivi/sota/core/daemon/DeltaListenerSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/daemon/DeltaListenerSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright: Copyright (C) 2016, ATS Advanced Telematic Systems GmbH
+ *  License: MPL-2.0
+ */
+package org.genivi.sota.core.daemon
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import eu.timepit.refined.api.Refined
+import org.genivi.sota.DefaultPatience
+import org.genivi.sota.core.{DatabaseSpec, FakeDeviceRegistry, UpdateService}
+import org.genivi.sota.core.client.FakeReposerverClient
+import org.genivi.sota.core.db.{Campaigns, Packages}
+import org.genivi.sota.core.resolver.DefaultConnectivity
+import org.genivi.sota.core.transfer.DefaultUpdateNotifier
+import org.genivi.sota.data.{Namespaces, PackageId, Uuid}
+import org.genivi.sota.messaging.Commit.Commit
+import org.genivi.sota.messaging.LocalMessageBus
+import org.genivi.sota.messaging.Messages.{DeltaGenerationFailed, GeneratedDelta}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FunSuite, ShouldMatchers}
+import org.genivi.sota.core.Generators.PackageGen
+
+import scala.concurrent.ExecutionContext
+
+class DeltaListenerSpec extends FunSuite
+  with DatabaseSpec
+  with ShouldMatchers
+  with ScalaFutures
+  with DefaultPatience
+  with Namespaces
+  with BeforeAndAfterAll {
+
+  implicit val ec = ExecutionContext.global
+  implicit val system = ActorSystem(this.getClass.getSimpleName)
+  implicit val mat = ActorMaterializer()
+
+  implicit val connectivity = DefaultConnectivity
+  val deviceRegistry = new FakeDeviceRegistry(Namespaces.defaultNs)
+  val updateService = new UpdateService(DefaultUpdateNotifier, deviceRegistry)
+  val tufClient = FakeReposerverClient
+  val publisher = LocalMessageBus.publisher(system)
+
+  val listener = new DeltaListener(deviceRegistry, updateService, publisher)
+
+  val from: Commit = Refined.unsafeApply("75857a45899985be4c4d941e90b6b396d6c92a4c7437aaf0bf102089fe21379d")
+  val to: Commit = Refined.unsafeApply("663ea1bfffe5038f3f0cf667f14c4257eff52d77ce7f2a218f72e9286616ea39")
+
+
+  test("ignores when message is not valid") {
+    val id = db.run(Campaigns.create(defaultNs, "some campaign")).futureValue
+    val msg = GeneratedDelta(id.underlying, defaultNs, from, to, 10L)
+    listener.generatedDeltaAction(msg).futureValue shouldBe Done
+  }
+
+  test("ignores when there is no lauch campaign request") {
+    val fromPid = PackageId(Refined.unsafeApply("treehub"), Refined.unsafeApply(from.value))
+    val toPid = PackageId(Refined.unsafeApply("treehub"), Refined.unsafeApply(to.value))
+    val pkgFrom = PackageGen.sample.get.copy(id = fromPid)
+    val pkgTo = PackageGen.sample.get.copy(id = toPid)
+
+    val dbio = for {
+      id <- Campaigns.create(defaultNs, "other campaign")
+      _ <- Packages.create(pkgFrom)
+      _ <- Packages.create(pkgTo)
+      _ <- Campaigns.setDeltaFrom(id, Some(fromPid))
+      _ <- Campaigns.setPackage(id, toPid)
+    } yield id
+
+    val campaignId = db.run(dbio).futureValue
+
+    val msg = GeneratedDelta(campaignId.underlying, defaultNs, from, to, 10L)
+
+    listener.generatedDeltaAction(msg).futureValue shouldBe Done
+  }
+
+  test("ignores non existent campaigns when receiving Generated messages") {
+    val msg = GeneratedDelta(Uuid.generate(), defaultNs, from, to, 10L)
+    listener.generatedDeltaAction(msg).futureValue shouldBe Done
+  }
+
+  test("ignores non existent campaigns when receiving failed messages") {
+    val msg = DeltaGenerationFailed(Uuid.generate(), defaultNs)
+
+    listener.deltaGenerationFailedAction(msg).futureValue shouldBe Done
+  }
+
+}

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -124,7 +124,8 @@ object SotaBuild extends Build {
 
   lazy val core = Project(id = "sota-core", base = file("core"))
     .settings( commonSettings ++ Migrations.settings ++ lintOptions ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.AmazonS3 :+ Dependencies.LibTuf :+ Dependencies.LibAts,
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.AmazonS3 :+
+        Dependencies.LibTuf :+ Dependencies.LibAts,
       testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi", "-l", "IntegrationTest"),
       testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi", "-n", "IntegrationTest"),
       parallelExecution in Test := true,


### PR DESCRIPTION
Simplify error handler in DeltaListener

This is also an example on how to not listen to messages. Kafka does
not gurantee exactly once semantics, so we need to be able to process
the messages twice. Logging an error and continuing is ok. failing on
the second message and not committing the queue offset is not.