### PR TITLE
[PRO-3590] update libtuf

### DIFF
--- a/core/src/test/scala/org/genivi/sota/core/client/FakeReposerverClient.scala
+++ b/core/src/test/scala/org/genivi/sota/core/client/FakeReposerverClient.scala
@@ -8,6 +8,7 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.libats.data.Namespace
 import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, RepoId, TargetName, TargetVersion}
+import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.TargetFormat
 import com.advancedtelematic.libtuf.reposerver._
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -19,7 +20,7 @@ import scala.concurrent.Future
 object FakeReposerverClient extends ReposerverClient {
 
   case class FakeTarget(namespace: Namespace, fileName: String, uri: Uri, checksum: Checksum,
-                        length: Int, name: Option[TargetName],
+                        length: Int, targetFormat: TargetFormat, name: Option[TargetName],
                         version: Option[TargetVersion],
                         hardwareIds: Seq[HardwareIdentifier])
 
@@ -33,11 +34,12 @@ object FakeReposerverClient extends ReposerverClient {
   }
 
   override def addTarget(namespace: Namespace, fileName: String, uri: Uri, checksum: Checksum,
-                         length: Int, name: Option[TargetName], version: Option[TargetVersion],
-                         hardwareIds: Seq[HardwareIdentifier]): Future[Unit] =
+                         length: Int, targetFormat: TargetFormat, name: Option[TargetName],
+                         version: Option[TargetVersion], hardwareIds: Seq[HardwareIdentifier]): Future[Unit] =
     store.asScala.get(namespace) match {
       case Some(repoId) =>
-        val newFakeTarget = FakeTarget(namespace, fileName, uri, checksum, length, name, version, hardwareIds)
+        val newFakeTarget = FakeTarget(namespace, fileName, uri, checksum, length,
+                                       targetFormat, name, version, hardwareIds)
 
         targets.compute(repoId, new BiFunction[RepoId, Seq[FakeTarget], Seq[FakeTarget]] {
           override def apply(repo: RepoId, old: Seq[FakeTarget]): Seq[FakeTarget] =

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -237,7 +237,7 @@ object Dependencies {
 
   val JsonWebSecurityVersion = "0.4.5"
 
-  val libTufV = "0.0.1-113-gf110d11"
+  val libTufV = "0.1.0-42-g149dcae"
 
   val libAtsV = "0.0.1-67-g052b15d"
 


### PR DESCRIPTION
The TreehubCommit listener needs to be updated to use a later
ReposerverClient, because currently addTarget fails.