### PR TITLE
[PRO-4083] TreehubCommit listener don't add targets with too big filepath

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/daemon/DeltaListener.scala
+++ b/core/src/main/scala/org/genivi/sota/core/daemon/DeltaListener.scala
@@ -11,12 +11,9 @@ import slick.jdbc.MySQLProfile.api._
 import org.genivi.sota.core.data.Campaign
 import org.slf4j.LoggerFactory
 import org.genivi.sota.messaging.Commit.Commit
-import cats.syntax._
-import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 import SotaCoreErrors._
-import org.genivi.sota.data.PackageId
 
 import scala.util.control.NoStackTrace
 
@@ -32,7 +29,6 @@ class DeltaListener(deviceRegistry: DeviceRegistry, updateService: UpdateService
     */
   private def validateMessage(campaign: Campaign, from: Commit, to: Commit)
                              (implicit ec: ExecutionContext): DBIO[Done] = {
-    import org.genivi.sota.data.Uuid
     import cats.implicits._
 
     val meta = campaign.meta


### PR DESCRIPTION
So I'm not super convinced this is what we really want to do, but this is the easiest fix.

I suppose other alternatives is to increase the allowed filepath length everywhere (ota-tuf, director, possibly auditor) but that seems like we will hit the same problem if we also don't put a limit on `Refname` in treehub.

Of course the best solution is for core to not add targets at all, and instead rely on the user that performs the garage-push to notice that the name is too long.