### PR TITLE
[PRO-4180] kafka listener dies if no tuf-repo exist

### DIFF
--- a/core/src/main/scala/org/genivi/sota/core/Boot.scala
+++ b/core/src/main/scala/org/genivi/sota/core/Boot.scala
@@ -12,7 +12,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Directive1, Route}
 import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
-import com.advancedtelematic.libtuf.reposerver.{ReposerverClient, ReposerverHttpClient}
+import com.advancedtelematic.libtuf_server.reposerver.{ReposerverClient, ReposerverHttpClient}
 import com.typesafe.config.ConfigFactory
 import org.genivi.sota.client.DeviceRegistryClient
 import org.genivi.sota.core.daemon.{DeltaListener, TreehubCommitListener}
@@ -218,7 +218,7 @@ object Boot extends BootApp
         MessageBusPublisher.ignore
     }
 
-  val tufClient = tufEndpoint.map(uri => new ReposerverHttpClient(uri))
+  val tufClient = tufEndpoint.map(uri => ReposerverHttpClient(uri))
 
   val interactionProtocol = config.getString("core.interactionProtocol")
 

--- a/core/src/test/scala/org/genivi/sota/core/client/FakeReposerverClient.scala
+++ b/core/src/test/scala/org/genivi/sota/core/client/FakeReposerverClient.scala
@@ -6,10 +6,10 @@ package org.genivi.sota.core.client
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
-import com.advancedtelematic.libats.data.Namespace
-import com.advancedtelematic.libtuf.data.TufDataType.{Checksum, HardwareIdentifier, RepoId, TargetName, TargetVersion}
+import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
+import com.advancedtelematic.libtuf.data.TufDataType.{HardwareIdentifier, RepoId, TargetName, TargetVersion}
 import com.advancedtelematic.libtuf.data.TufDataType.TargetFormat.TargetFormat
-import com.advancedtelematic.libtuf.reposerver._
+import com.advancedtelematic.libtuf_server.reposerver._
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction

--- a/core/src/test/scala/org/genivi/sota/core/daemon/TreehubCommitListenerSpec.scala
+++ b/core/src/test/scala/org/genivi/sota/core/daemon/TreehubCommitListenerSpec.scala
@@ -52,7 +52,7 @@ class TreehubCommitListenerSpec extends FunSuite
       size = 1234, uri = "some_uri")
 
     for {
-      repoId   <- tufClient.createRoot(com.advancedtelematic.libats.data.Namespace(defaultNs.get))
+      repoId   <- tufClient.createRoot(com.advancedtelematic.libats.data.DataType.Namespace(defaultNs.get))
       _   <- listener.action(event)
     } yield (repoId, event)
   }

--- a/project/SotaBuild.scala
+++ b/project/SotaBuild.scala
@@ -124,8 +124,7 @@ object SotaBuild extends Build {
 
   lazy val core = Project(id = "sota-core", base = file("core"))
     .settings( commonSettings ++ Migrations.settings ++ lintOptions ++ Seq(
-      libraryDependencies ++= Dependencies.Rest ++ Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.AmazonS3 :+
-        Dependencies.LibTuf :+ Dependencies.LibAts,
+      libraryDependencies ++= Dependencies.Rest ++ Dependencies.LibTuf ++ Dependencies.Circe :+ Dependencies.Cats :+ Dependencies.AmazonS3 :+ Dependencies.LibAts,
       testOptions in UnitTests += Tests.Argument(TestFrameworks.ScalaTest, "-l", "RequiresRvi", "-l", "IntegrationTest"),
       testOptions in IntegrationTests += Tests.Argument(TestFrameworks.ScalaTest, "-n", "RequiresRvi", "-n", "IntegrationTest"),
       parallelExecution in Test := true,
@@ -237,9 +236,9 @@ object Dependencies {
 
   val JsonWebSecurityVersion = "0.4.5"
 
-  val libTufV = "0.1.0-125-g26a9c02"
+  val libTufV = "0.2.0-16-ga0d6f7a"
 
-  val libAtsV = "0.0.1-67-g052b15d"
+  val libAtsV = "0.1.0-5-g6b585f0"
 
   val AkkaHttp = "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion
 
@@ -327,7 +326,10 @@ object Dependencies {
 
   lazy val Kafka = "com.typesafe.akka" %% "akka-stream-kafka" % "0.16"
 
-  lazy val LibTuf = "com.advancedtelematic" %% "libtuf" % libTufV
+  lazy val LibTuf = Seq(
+    "com.advancedtelematic" %% "libtuf" % libTufV,
+    "com.advancedtelematic" %% "libtuf-server" % libTufV
+  )
 
   lazy val LibAts = "com.advancedtelematic" %% "libats" % libAtsV
 


### PR DESCRIPTION
So for now if the repo don't exists we will ignore adding a tuf target, hopefully we will stop relying on this listener soon.